### PR TITLE
Add Sidon set reference

### DIFF
--- a/constants/5.md
+++ b/constants/5.md
@@ -10,6 +10,7 @@ $C_5$ is the smallest constant such that Sidon sets in $\{1,\dots,N\}$ have card
 | ----- | --------- | -------- |
 | $1$ | [ET41], [Li69] | |
 | $0.998$ | [BFR21] | |
+| $0.99703$ | [OBO22] | |
 | $0.98183$ | [CHO25] | |
 | $0.97633$ | Carter, Georgiev, Gomez--Serrano, Hunter, O'Bryant, Tao, Wagner ([unpublished](https://terrytao.wordpress.com/2025/11/05/mathematical-exploration-and-discovery-at-scale/#comment-689052), 2025) | AlphaEvolve |
 


### PR DESCRIPTION
Added a line in the table for Kevin O'Bryant's paper "On the size of finite Sidon sets" (the reference already existed, it just wasn't included in the table).