### PR TITLE
Update to matrix multiplication exponent

### DIFF
--- a/constants/15.md
+++ b/constants/15.md
@@ -15,6 +15,9 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 | $2.373$ | [Z2012] |  |
 | $2.3728639$ | [L2014] |  |
 | $2.3728596$ | [AV2020] | Improved analysis of the laser method. |
+| $2.371866$ | [DWZ23] | This and subsequent improvements introduce and optimize an asymmetric modification of the laser method. |
+| $2.371552$ | [WXXZ24] |  |
+| $2.371339$ | [ADWXXZ25] |  |
 
 ## Known lower bounds
 
@@ -44,6 +47,10 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
 - [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* TheoretiCS **3** (2024), article 21. Conference paper in SODA 2021, 522–539. arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.
+- [DWZ2022] Duan, R; Wu, H.; Zhou, R. *Faster matrix multiplication via asymmetric hashing.* In FOCS 2023, 2129–2138. arXiv:2210.10173.
+- [VXXZ2023] Vassilevska Williams, V.; Xu, Y.; Xu, Z.; Zhou, R. *New bounds for matrix multiplication: from Alpha to Omega.* In SODA 2024, 3792–3835. arXiv:2307.07970.
+- [ADVXXZ2024] Alman, J.; Duan, R.; Vassilevska Williams, V.; Xu, Y.; Xu, Z.; Zhou, R. *More asymmetry yields faster matrix multiplication.* In SODA 2025, 2005–2039. arXiv:2404.16349.
+
 
 ## Contribution notes
 

--- a/constants/15.md
+++ b/constants/15.md
@@ -8,13 +8,13 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 |-------|-----------|----------|
 | 3 | Trivial | |
 | $2.8074$ | [S1969] |  |
-| $2.4785$ | [S1987] |  |
-| $2.496$ | [CW1990] |  |
-| $2.373689703$ | [S2010, DS2013] |  |
-| $2.372873$ | [V2012, V2014] | optimized Coppersmith–Winograd framework. |
+| $2.4785$ | [S1987] | Introduces laser method. |
+| $2.496$ | [CW1990] | Introduces Coppersmith-Winograd tensors. |
+| $2.373689703$ | [S2010, DS2013] | This and subsequent improvements up to [L2014] modify and optimize the framework of Coppersmith-Winograd to analyze higher powers of the tensor. |
+| $2.372873$ | [V2012, V2014] |  |
 | $2.373$ | [Z2012] |  |
 | $2.3728639$ | [L2014] |  |
-| $< 2.3728596$ | [AV2020] | laser method analysis. |
+| $2.3728596$ | [AV2020] | Improved analysis of the laser method. |
 
 ## Known lower bounds
 

--- a/constants/15.md
+++ b/constants/15.md
@@ -42,7 +42,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [V2014] Vassilevska Williams, V. *Multiplying matrices in $O(n^{2.373})$ time.* Unpublished note (2014), [https://theory.stanford.edu/~virgi/matrixmult-f.pdf](https://theory.stanford.edu/~virgi/matrixmult-f.pdf)
 - [LG2014] Le Gall, F. *Powers of tensors and fast matrix multiplication.* In ISSAC 2014, 296–303.
 - [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
-- [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* In STOC 2021, arXiv:2010.05846.
+- [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* In SODA 2021, 522–539; arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.
 
 ## Contribution notes

--- a/constants/15.md
+++ b/constants/15.md
@@ -28,7 +28,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 ## Additional comments and links
 
 - The true value of $\omega$ affects the best possible running time of many other algorithms, including all-pairs shortest paths (APSP), transitive closure, and determinant computation.
-- A survey of the topic can be found at [V2020].
+- A survey of the topic can be found at [V2012a].
 - The group-theoretic approach cannot obtain upper bounds better than 2.3725 [AHU2021].
 - See also: [Wikipedia page on matrix multiplication exponent](https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm).
 
@@ -40,11 +40,11 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [CW1990] Coppersmith, D.; Winograd, S. *Matrix multiplication via arithmetic progressions.* J. Symbolic Computation **9** (1990), 251–280.
 - [S2010] Stothers, A. J. *On the complexity of matrix multiplication.* PhD thesis, University of Edinburgh (2010).
 - [V2012] Vassilevska Williams, V. *Multiplying matrices faster than Coppersmith–Winograd.* In STOC 2012, 887–898.
+- [V2012a] Vassilevska Williams, V. *An overview of the recent progress on the exponent of matrix multiplication.* SIGACT News **43(4)** (2012), 57–59.
 - [Z2012] Zhdanovich, D. V. *The matrix capacity of a tensor.* J. Mathematical Sciences **186** (2012), 599–643.
 - [DS2013] Davie, A. M.; Stothers, A. J. *Improved bound for complexity of matrix multiplication.* Proc. Royal Society of Edinburgh A **143** (2013), 351–369.
 - [V2014] Vassilevska Williams, V. *Multiplying matrices in $O(n^{2.373})$ time.* Unpublished note (2014), [https://theory.stanford.edu/~virgi/matrixmult-f.pdf](https://theory.stanford.edu/~virgi/matrixmult-f.pdf)
 - [LG2014] Le Gall, F. *Powers of tensors and fast matrix multiplication.* In ISSAC 2014, 296–303.
-- [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
 - [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* TheoretiCS **3** (2024), article 21. Conference paper in SODA 2021, 522–539. arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.
 - [DWZ2022] Duan, R; Wu, H.; Zhou, R. *Faster matrix multiplication via asymmetric hashing.* In FOCS 2023, 2129–2138. arXiv:2210.10173.

--- a/constants/15.md
+++ b/constants/15.md
@@ -9,7 +9,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 | 3 | Trivial | |
 | $2.8074$ | [S1969] |  |
 | $2.496$ | [CW1990] |  |
-| $2.3728639$ | [V2012] | optimized Coppersmith–Winograd framework. |
+| $2.372873$ | [V2012, V2014] | optimized Coppersmith–Winograd framework. |
 | $< 2.3728596$ | [AV2020] | laser method analysis. |
 
 ## Known lower bounds
@@ -31,6 +31,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [S1969] Strassen, V. *Gaussian elimination is not optimal.* Numerische Mathematik **13** (1969), 354–356.
 - [CW1990] Coppersmith, D.; Winograd, S. *Matrix multiplication via arithmetic progressions.* J. Symbolic Computation **9** (1990), 251–280.
 - [V2012] Vassilevska Williams, V. *Multiplying matrices faster than Coppersmith–Winograd.* In STOC 2012, 887–898.
+- [V2014] Vassilevska Williams, V. *Multiplying matrices in $O(n^{2.373})$ time.* Unpublished note (2014), [https://theory.stanford.edu/~virgi/matrixmult-f.pdf](https://theory.stanford.edu/~virgi/matrixmult-f.pdf)
 - [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
 - [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* In STOC 2021, arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.

--- a/constants/15.md
+++ b/constants/15.md
@@ -8,8 +8,12 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 |-------|-----------|----------|
 | 3 | Trivial | |
 | $2.8074$ | [S1969] |  |
+| $2.4785$ | [S1987] |  |
 | $2.496$ | [CW1990] |  |
+| $2.373689703$ | [S2010, DS2013] |  |
 | $2.372873$ | [V2012, V2014] | optimized Coppersmith–Winograd framework. |
+| $2.373$ | [Z2012] |  |
+| $2.3728639$ | [L2014] |  |
 | $< 2.3728596$ | [AV2020] | laser method analysis. |
 
 ## Known lower bounds
@@ -29,9 +33,14 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 ## References
 
 - [S1969] Strassen, V. *Gaussian elimination is not optimal.* Numerische Mathematik **13** (1969), 354–356.
+- [S1987] Strassen, V. *Relative bilinear complexity and matrix multiplication.* J. reine angew. Math. **375/376** (1987), 406–443.
 - [CW1990] Coppersmith, D.; Winograd, S. *Matrix multiplication via arithmetic progressions.* J. Symbolic Computation **9** (1990), 251–280.
+- [S2010] Stothers, A. J. *On the complexity of matrix multiplication.* PhD thesis, University of Edinburgh (2010).
 - [V2012] Vassilevska Williams, V. *Multiplying matrices faster than Coppersmith–Winograd.* In STOC 2012, 887–898.
+- [Z2012] Zhdanovich, D. V. *The matrix capacity of a tensor.* J. Mathematical Sciences **186** (2012), 599–643.
+- [DS2013] Davie, A. M.; Stothers, A. J. *Improved bound for complexity of matrix multiplication.* Proc. Royal Society of Edinburgh A **143** (2013), 351–369.
 - [V2014] Vassilevska Williams, V. *Multiplying matrices in $O(n^{2.373})$ time.* Unpublished note (2014), [https://theory.stanford.edu/~virgi/matrixmult-f.pdf](https://theory.stanford.edu/~virgi/matrixmult-f.pdf)
+- [LG2014] Le Gall, F. *Powers of tensors and fast matrix multiplication.* In ISSAC 2014, 296–303.
 - [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
 - [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* In STOC 2021, arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.

--- a/constants/15.md
+++ b/constants/15.md
@@ -10,6 +10,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 | $2.8074$ | [S1969] |  |
 | $2.4785$ | [S1987] | Introduces laser method. |
 | $2.496$ | [CW1990] | Introduces Coppersmith-Winograd tensors. |
+| $2.41$ | [CKSU2005] | Uses an alternative group-theoretic method. |
 | $2.373689703$ | [S2010, DS2013] | This and subsequent improvements up to [L2014] modify and optimize the framework of Coppersmith-Winograd to analyze higher powers of the tensor. |
 | $2.372873$ | [V2012, V2014] |  |
 | $2.373$ | [Z2012] |  |
@@ -38,6 +39,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [S1969] Strassen, V. *Gaussian elimination is not optimal.* Numerische Mathematik **13** (1969), 354–356.
 - [S1987] Strassen, V. *Relative bilinear complexity and matrix multiplication.* J. reine angew. Math. **375/376** (1987), 406–443.
 - [CW1990] Coppersmith, D.; Winograd, S. *Matrix multiplication via arithmetic progressions.* J. Symbolic Computation **9** (1990), 251–280.
+- [CKSU2005] Cohn, H.; Kleinberg, R.; Szegedy, B.; Umans, C. *Group-theoretic algorithms for matrix multiplication.* In FOCS 2005, 379–388.
 - [S2010] Stothers, A. J. *On the complexity of matrix multiplication.* PhD thesis, University of Edinburgh (2010).
 - [V2012] Vassilevska Williams, V. *Multiplying matrices faster than Coppersmith–Winograd.* In STOC 2012, 887–898.
 - [V2012a] Vassilevska Williams, V. *An overview of the recent progress on the exponent of matrix multiplication.* SIGACT News **43(4)** (2012), 57–59.

--- a/constants/15.md
+++ b/constants/15.md
@@ -42,7 +42,7 @@ We define $C_{15}$ to be the matrix multiplication exponent $\omega$, the smalle
 - [V2014] Vassilevska Williams, V. *Multiplying matrices in $O(n^{2.373})$ time.* Unpublished note (2014), [https://theory.stanford.edu/~virgi/matrixmult-f.pdf](https://theory.stanford.edu/~virgi/matrixmult-f.pdf)
 - [LG2014] Le Gall, F. *Powers of tensors and fast matrix multiplication.* In ISSAC 2014, 296–303.
 - [V2020] Vassilevska Williams, V. *Recent progress on the exponent of matrix multiplication.* ACM SIGACT News, 2020.
-- [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* In SODA 2021, 522–539; arXiv:2010.05846.
+- [AV2020] Alman, J.; Vassilevska Williams, V. *A refined laser method and faster matrix multiplication.* TheoretiCS **3** (2024), article 21. Conference paper in SODA 2021, 522–539. arXiv:2010.05846.
 - [AHU2021] Alman, J.; Hopkins, B.; Umans, C. *The limitations of the group-theoretic approach to matrix multiplication.* FOCS 2021, arXiv:2107.12802.
 
 ## Contribution notes


### PR DESCRIPTION
- Added history of upper bounds using laser method or group-theoretic method (since 1897)
- Corrected the upper bound of [V2012], the conference paper contained a mistake
- Fixed and updated some existing references

