### PR TITLE
Update and fix references, fix rendering issues, and changed conjecture wording

### DIFF
--- a/constants/9a.md
+++ b/constants/9a.md
@@ -10,9 +10,11 @@ C_{9} := \Theta({\mathcal C}_{7}),
 $$
 
 where for a graph $G$, the Shannon capacity $\Theta(G)$ is defined by
+
 $$
 \Theta(G) := \sup_{n \ge 1} \alpha(G^{\boxtimes n})^{1/n}.
 $$
+
 Here $\alpha(H)$ denotes the independence number of a graph $H$, and $\boxtimes$
 is the strong graph product.
 
@@ -41,22 +43,22 @@ is the strong graph product.
 
 - Equivalently, $\Theta(G)$ is the maximum zero-error information rate of a noisy
 channel whose confusability graph is $G$.
--  Determining $\Theta({\mathcal C}_{2k+1})$ for odd cycles is a central open problem in information theory and extremal combinatorics.
-- For ${\mathcal C}_{5}$, Lovász famously proved $\Theta({\mathcal C}_{5})=\sqrt{5}$, but no exact value is
+- Determining $\Theta({\mathcal C}_{2k+1})$ for odd cycles is a central open problem in information theory and extremal combinatorics.
+- For ${\mathcal C}\_{5}$, Lovász famously proved $\Theta({\mathcal C}\_{5})=\sqrt{5}$, but no exact value is
   known for $\Theta({\mathcal C}_{7})$.
-- It is widely conjectured that $\Theta({\mathcal C}_{2k+1})=\vartheta({\mathcal C}_{2k+1})$ for all $k$,
+- It is possible that $\Theta({\mathcal C}\_{2k+1})=\vartheta({\mathcal C}\_{2k+1})$ for all $k$,
   but this is currently open beyond $k=2$.
 
 ## References
 
-- [BMRRST1971] L. Baumert, R. McEliece, E. Rodemich, H. Rumsey, R. Stanley, H. Taylor, A combinatorial packing
-problem, Computers in Algebra and Number Theory, American Mathematical Society, Providence,
+- [BMRRST1971] L. Baumert, R. McEliece, E. Rodemich, H. Rumsey, R. Stanley, H. Taylor. *A combinatorial packing
+problem*. Computers in Algebra and Number Theory, American Mathematical Society, Providence,
 RI (1971), 97–108.
 - [L1979] Lovász, L. *On the Shannon capacity of a graph*. IEEE Transactions on Information Theory **25** (1979), 1–7.
-- [PS2018] Sven Polak, Alexander Schrijver, New lower bound on the Shannon capacity of $C_{9}$ from circular graphs, arXiv:1808.07438.
-- [MO2017] K.A. Mathew, P.R.J. Östergård, New lower bounds for the Shannon capacity of odd cycles, ¨ Designs,
+- [PS2018] Sven Polak, Alexander Schrijver. *New lower bound on the Shannon capacity of C7 from circular graphs*. Information Processing Letters, 143 (2019), 37-40. arXiv:1808.07438.
+- [MO2017] K.A. Mathew, P.R.J. Östergård. *New lower bounds for the Shannon capacity of odd cycles*. Designs,
 Codes and Cryptography, 84 (2017), 13–22.
-- [VZ2002] A. Vesel, J. Zerovnik, Improved lower bound on the Shannon capacity of $C_{9}$, Information Processing
+- [VZ2002] A. Vesel, J. Zerovnik, Improved lower bound on the Shannon capacity of $C_7$, Information Processing
 Letters, 81 (2002), 277–282.
 
 ## Contribution notes


### PR DESCRIPTION
Fixed: C7 was called C9 in the references. 
Fixed: Combination of underscores, stars and math were giving rendering issues.
Fixed: display math required empty lines to render
Changed: "widely conjectured" into "possible"