### PR TITLE
Add constant 49 (Erdos-Szemeredi 3-sunflower-free capacity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ We are arbitrarily numbering the constants as $C_{1}$, $C_{2}$, etc., mostly bas
 | [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490941 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
 | [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 9 |
+| [49](https://teorth.github.io/optimizationproblems/constants/49a.html) | Erdős–Szemerédi $3$-sunflower-free capacity | >1.551 (>=1.554 unpublished) | $\frac{3}{2^{2/3}} \approx 1.88988$ |
 
 
 ## Recent progress

--- a/constants/49a.md
+++ b/constants/49a.md
@@ -1,0 +1,91 @@
+# Erdős–Szemerédi $3$-sunflower-free capacity
+
+## Description of constant
+
+A family of three distinct sets $A,B,C$ is a **$3$-sunflower** (or $\Delta$-system) if
+$$
+A\cap B \ =\ A\cap C \ =\ B\cap C.
+$$
+A family of sets is **sunflower-free** if it contains no $3$-sunflower (equivalently, no sunflower of any size $\ge 3$).
+
+Let $[n]:=\{1,2,\dots,n\}$ and let $f(n)$ denote the maximum size of a sunflower-free family $\mathcal{F}\subseteq 2^{[n]}$.
+Define
+$$
+C_{49}\ :=\ \mu^{\mathrm S}\_3\ :=\ \limsup\_{n\to\infty} f(n)^{1/n}.
+$$
+A standard tensor power argument shows that the limsup is in fact a limit:
+$$
+\mu^{\mathrm S}\_3\ =\ \lim\_{n\to\infty} f(n)^{1/n}
+$$
+(see e.g. [TZ2025, (1.2)]).
+
+### Existence of the limit
+
+The limit exists.  One convenient way to see this is to reduce to **uniform** families and then apply a tensor-power (direct sum) argument (see also [TZ2025]).
+
+For $0\le r\le n$, let $f\_{r}(n)$ denote the maximum size of a sunflower-free $r$-uniform family $\mathcal{F}\subseteq \binom{[n]}{r}$, and set
+$$
+g(n)\ :=\ \max_{0\le r\le n} f\_{r}(n).
+$$
+Then
+$$
+g(n)\ \le\ f(n)\ \le\ (n+1)\,g(n),
+$$
+since any family $\mathcal{F}\subseteq 2^{[n]}$ decomposes as the disjoint union of its uniform layers $\mathcal{F}\cap\binom{[n]}{r}$ and one layer must have size at least $\lvert\mathcal{F}\rvert/(n+1)$.
+
+Now let $X,Y$ be disjoint sets with $\lvert X\rvert=n$ and $\lvert Y\rvert=m$, and let $\mathcal{F}\subseteq \binom{X}{r}$ and $\mathcal{G}\subseteq \binom{Y}{s}$ be sunflower-free.  Define the product family
+$$
+\mathcal{F}\otimes\mathcal{G}\ :=\ \{A\cup B:\ A\in\mathcal{F},\ B\in\mathcal{G}\}\ \subseteq\ \binom{X\cup Y}{r+s}.
+$$
+Then $\mathcal{F}\otimes\mathcal{G}$ is sunflower-free.  Indeed, suppose that three distinct members $A\_i\cup B\_i$ ($i=1,2,3$) form a $3$-sunflower in $X\cup Y$.  Since $X$ and $Y$ are disjoint, the equalities
+$$
+(A_1\cup B_1)\cap(A_2\cup B_2)\ =\ (A_1\cup B_1)\cap(A_3\cup B_3)\ =\ (A_2\cup B_2)\cap(A_3\cup B_3)
+$$
+imply
+$$
+A_1\cap A_2\ =\ A_1\cap A_3\ =\ A_2\cap A_3
+$$
+and
+$$
+B_1\cap B_2\ =\ B_1\cap B_3\ =\ B_2\cap B_3.
+$$
+If two of the $A\_i$ coincide, say $A\_1=A\_2$, then $A\_1=A\_1\cap A\_2=A\_1\cap A\_3\subseteq A\_3$, and uniformity forces $A\_1=A\_3$.
+Thus either $(A\_1,A\_2,A\_3)$ is a triple of distinct sets forming a $3$-sunflower in $\mathcal{F}$, or all three $A\_i$ coincide; similarly for the $B\_i$.
+Since the unions $A\_i\cup B\_i$ are distinct, at least one of the triples $(A\_1,A\_2,A\_3)$ or $(B\_1,B\_2,B\_3)$ consists of three distinct sets, giving a contradiction.
+
+Consequently $g(n+m)\ge g(n)g(m)$, so $\log g(n)$ is superadditive.  By Fekete's lemma, the limit $\lim\_{n\to\infty} g(n)^{1/n}$ exists.  Since $f(n)$ and $g(n)$ differ by at most the factor $(n+1)$, it follows that $\lim\_{n\to\infty} f(n)^{1/n}$ exists as well.
+
+Trivially $1\le \mu^{\mathrm S}\_3 \le 2$.
+
+## Known upper bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $2$ | Trivial | $f(n)\le 2^n$. |
+| $\frac{3}{2^{2/3}} \approx 1.8898815748$ | [NS2017] | They prove $\lvert\mathcal{F}\rvert \le 3(n+1) \sum\_{k=0}^{\lfloor n/3\rfloor} \binom{n}{k} \le \left(\frac{3}{2^{2/3}}\right)^{n(1+o(1))}$ for sunflower-free $\mathcal{F}\subseteq 2^{[n]}$. |
+
+## Known lower bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $1$ | Trivial | $f(n)\ge 1$. |
+| $>1.551$ | [DEGKM1997] | This lower bound is obtained from a construction of Deuber--Erdős--Gunderson--Kostochka--Meyer. The numerical value is stated in [FPP2024], [TZ2025]. |
+| $\ge 1.554$ (unpublished) | [NS2017] | The arXiv preprint version of [NS2017] records $\mu^{\mathrm S}\_3\ge 1.554$, citing an unpublished manuscript of the first author. |
+
+## Additional comments and links
+
+- Erdős and Szemerédi conjectured that $\mu^{\mathrm S}\_3<2$ [ES1978]; this was proved by Naslund--Sawin via the polynomial method. [NS2017]
+- This constant is also called the Erdős–Szemerédi $3$-sunflower-free capacity; see e.g. [NS2017], [TZ2025].
+- [Wikipedia page on sunflowers](https://en.wikipedia.org/wiki/Sunflower_(mathematics))
+
+## References
+
+- [DEGKM1997] Deuber, W. A.; Erdős, P.; Gunderson, D. S.; Kostochka, A. V.; Meyer, A. G. *Intersection statements for systems of sets.* J. Combin. Theory Ser. A **79** (1997), 118--132. DOI: 10.1006/jcta.1997.2778.
+- [ES1978] Erdős, P.; Szemerédi, E. *Combinatorial properties of systems of sets.* J. Combin. Theory Ser. A **24** (1978), 308--313. DOI: 10.1016/0097-3165(78)90060-2.
+- [FPP2024] Frankl, Peter; Pach, János; Pálvölgyi, Dömötör. *Odd-sunflowers.* J. Combin. Theory Ser. A **206** (2024), 105889. DOI: 10.1016/j.jcta.2024.105889. [arXiv:2310.16701](https://arxiv.org/abs/2310.16701).
+- [NS2017] Naslund, Eric; Sawin, William F. *Upper bounds for sunflower-free sets.* Forum Math. Sigma **5** (2017), e15. DOI: 10.1017/fms.2017.12. [arXiv:1606.09575](https://arxiv.org/abs/1606.09575).
+- [TZ2025] Tang, Quanyu; Zhang, Shengtong. *Harmonic LCM patterns and sunflower-free capacity.* [arXiv:2512.20055](https://arxiv.org/abs/2512.20055) (2025).
+
+## Contribution notes
+
+Prepared with assistance from ChatGPT 5.2.


### PR DESCRIPTION
Adds constants/49a.md with current bounds and references.
 
Numbered 49a to avoid PR #35 (48a).