### PR TITLE
Update C45 upper bound to 0.490341 (Chen-Dai-Li 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We are arbitrarily numbering the constants as $C_{1}$, $C_{2}$, etc., mostly bas
 | [42](https://teorth.github.io/optimizationproblems/constants/42a.html) | Turan's pure power sum constant | 0.5 | 0.69368 |
 | [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.8559 | 0.86602540378 |
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |
-| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490941 |
+| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490341088858244 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
 | [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 9 |
 

--- a/constants/45a.md
+++ b/constants/45a.md
@@ -11,6 +11,7 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 | $1/2=0.5$ | Trivial |  |
 | $<0.5$ | [E1950] | Used covering systems |
 | $0.490941$ | [HR2006] | |
+| $0.490341088858244$ | [CDL2024] | |
 
 ## Known lower bounds
 
@@ -32,7 +33,8 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 ## References
 
 
-- [CS2004] Y.G. Chen and X.G. Sun, "On Romanoff’s constant," J. Number Theory, 106 (2004), 275–284.
+- [CDL2024] Y. Chen, X. Dai, and H. Li, "Some results on a conjecture of de Polignac about numbers of the form $p + 2^k$," [arXiv:2402.06644](https://arxiv.org/abs/2402.06644), 2024.
+- [CS2004] Y.G. Chen and X.G. Sun, "On Romanoff's constant," J. Number Theory, 106 (2004), 275–284.
 - [CE2018] C. Elsholtz and J.-C. Schlage-Puchta, "On the density of sums of primes and powers of two," Acta Arithmetica, 183 (2018), 1-20.
 - [E1950] P. Erdős, "On integers of the form $2^k+p$ and some related problems," Summa Brasil. Math., 2 (1950), 113–123.
 - [HR2006] L. Habsieger and X. Roblot, "On integers of the form $p + 2^k$," Acta Arithmetica, 122 (2006), 45–50.


### PR DESCRIPTION
## Summary
- Improve the best known upper bound for Romanoff's constant (C₄₅) from 0.490941 to 0.490341088858244
- Based on Y. Chen, X. Dai, and H. Li, "Some results on a conjecture of de Polignac about numbers of the form $p + 2^k$," [arXiv:2402.06644](https://arxiv.org/abs/2402.06644), 2024

## Changes
- `constants/45a.md`: Added new upper bound row and reference [CDL2024]
- `README.md`: Updated best upper bound in the table