### PR TITLE
Update 31a: new lower bound 0.79970 for binary Chvátal–Sankoff constant

### DIFF
--- a/constants/31a.md
+++ b/constants/31a.md
@@ -22,6 +22,7 @@ Then $C\_{31a}$ is the (well-defined) limit $C\_{31a} := \lim\_{n \to \infty}\fr
 | $0.773911$ | [D1994] | Computer assisted |
 | $0.788071$ | [L2009] | Computer assisted |
 | $0.792665992$ | [H2024] | Computer assisted |
+| $0.79970$ | [AA2026] | AI and computer assisted |
 
 ## Additional comments
 
@@ -34,3 +35,4 @@ Then $C\_{31a}$ is the (well-defined) limit $C\_{31a} := \lim\_{n \to \infty}\fr
 - [L2009] Lueker, George S. "Improved bounds on the average length of longest common subsequences." Journal of the ACM (JACM) 56.3 (2009): 1-38. Available at https://dl.acm.org/doi/pdf/10.1145/1516512.1516519
 - [DP1995] Dančík, Vlado, and Mike Paterson. "Upper bounds for the expected length of a longest common subsequence of two binary sequences." Random Structures & Algorithms 6.4 (1995): 449-458. Available at https://onlinelibrary.wiley.com/doi/pdf/10.1002/rsa.3240060408
 - [D1994] Dancík, Vladimír. Expected length of longest common subsequences. Diss. University of Warwick, 1994. Available at https://wrap.warwick.ac.uk/id/eprint/107547/1/WRAP_Theses_Dancik_1994.pdf
+- [AA2026] Archivara Agent. "An Improved Lower Bound on the Chvátal–Sankoff Constant for Binary Strings via Monte Carlo Beam Search." (2026). Available at https://archivara.org/paper/1a5c6a48-a106-40e4-a5f0-97833f3a25a7. Code and reproducible data at https://github.com/spicylemonade/constant.


### PR DESCRIPTION
## Summary

- Adds a new lower bound $0.79970$ for $C_{31a}$ (Chvátal–Sankoff constant, binary alphabet), improving upon Heineman et al. (2024) bound of $0.792665992$ by $+0.00703$.
- Method: Monte Carlo beam search heuristic (1M trials, N=1000, W=100) combined with Hoeffding concentration inequality.
- Result independently reproduced; raw trial data archived with SHA-256 hash.

## References

- Paper: https://archivara.org/paper/1a5c6a48-a106-40e4-a5f0-97833f3a25a7
- Code and data: https://github.com/spicylemonade/constant

## AI disclosure

This bound was obtained by an AI agent (Archivara). The result and all references have been verified by the human contributor. This entry was also prepared with AI assistance.