### PR TITLE
Add constant 80 (Ising perceptron capacity threshold)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ We are arbitrarily numbering the constants as $C_{1}$, $C_{2}$, etc., mostly bas
 | [77](https://teorth.github.io/optimizationproblems/constants/77a.html) | 3D critical Bochner–Riesz exponent | 3 | $\frac{13}{4}$ |
 | [78](https://teorth.github.io/optimizationproblems/constants/78a.html) | Conway thrackle constant | 1 | 1.393 |
 | [79](https://teorth.github.io/optimizationproblems/constants/79a.html) | Asymptotic essential-dimension ratio of the symmetric groups | $\frac{1}{2}$ | 1 |
+| [80](https://teorth.github.io/optimizationproblems/constants/80a.html) | Ising perceptron capacity threshold | >0 (0.833*) | 0.847 (0.833*) |
 
 
 ## Recent progress

--- a/constants/80a.md
+++ b/constants/80a.md
@@ -8,20 +8,20 @@ Z(G) := \left| \left\{ \sigma \in \{-1,1\}^N : G \sigma \geq 0 \text{ coordinate
 $$
 This is the zero-margin binary (or Ising) perceptron.  Write $M = \lfloor \alpha N \rfloor$.
 
-Define $C_{80a}$ to be the infimum of all $\alpha > 0$ such that
+Define $C_{80}$ to be the infimum of all $\alpha > 0$ such that
 $$
 \mathbb{P}(Z(G) > 0) \to 0 \qquad \text{as } N \to \infty.
 $$
-Equivalently, $C_{80a}$ is the asymptotic storage-capacity / satisfiability threshold of the zero-margin Ising perceptron.  Sharp-threshold results [X2021], [NS2023] show that this formulation captures the threshold location up to $o(1)$.
+Equivalently, $C_{80}$ is the asymptotic storage-capacity / satisfiability threshold of the zero-margin Ising perceptron.  Sharp-threshold results [X2021], [NS2023] show that this formulation captures the threshold location up to $o(1)$.
 
 ## Known upper bounds
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $<1$ | [KR1998] | Kim--Roche prove that the capacity is bounded away from $1$ with high probability. |
+| $<1$ | [KR1998] | Kim–Roche prove that the capacity is bounded away from $1$ with high probability. |
 | $0.9963$ | [KR1998] | Explicit combinatorial upper bound. |
 | $<1$ | [T1999] | Independent non-explicit upper bound of the form $1-\varepsilon$ for some $\varepsilon>0$. |
-| $0.847$ | [AT2024] | Complete proof of the upper bound outlined earlier by Krauth M\'ezard. |
+| $0.847$ | [AT2024] | Complete proof of the upper bound outlined earlier by Krauth–Mézard. |
 | $\alpha_{\star} \approx 0.833$ | [H2024] | Conditional on an explicit numerical maximization hypothesis for a two-variable function $\mathscr{S}_{\star}(\lambda_1,\lambda_2)$. |
 
 ## Known lower bounds
@@ -30,21 +30,21 @@ Equivalently, $C_{80a}$ is the asymptotic storage-capacity / satisfiability thre
 | ----- | --------- | -------- |
 | $0$ | Trivial | |
 | $>0$ | [KR1998] | Shows the capacity is bounded away from zero with high probability. |
-| $\alpha_{\star} \approx 0.833$ | [DS2025], [NS2023] | Conditional on an explicit numerical maximization hypothesis for a one-variable function $\mathscr{S}_{\star}(\lambda)$; Ding--Sun prove the lower bound with positive probability, and the sharp-threshold theory of Nakajima--Sun upgrades this to with high probability for every $\alpha < \alpha_{\star}$. |
+| $\alpha_{\star} \approx 0.833$ | [DS2025], [NS2023] | Conditional on an explicit numerical maximization hypothesis for a one-variable function $\mathscr{S}_{\star}(\lambda)$; Ding–Sun prove the lower bound with positive probability, and the sharp-threshold theory of Nakajima–Sun upgrades this to with high probability for every $\alpha < \alpha_{\star}$. |
 
 ## Additional comments
 
-- The physics prediction of Krauth--M\'ezard [KM1989] is that $C_{80a} = \alpha_{\star} \approx 0.833$.
+- The physics prediction of Krauth–Mézard [KM1989] is that $C_{80} = \alpha_{\star} \approx 0.833$.
 - The literature uses both the names _binary perceptron_ and _Ising perceptron_ for this model.
-- Huang [H2024], together with Ding--Sun [DS2025], gives a conditional proof of the Krauth M\'ezard prediction.
-- The explicit upper bound $0.9963$ comes from Kim--Roche [KR1998]; Talagrand [T1999] obtained an independent non-explicit upper bound.
+- Huang [H2024], together with Ding–Sun [DS2025], gives a conditional proof of the Krauth–Mézard prediction.
+- The explicit upper bound $0.9963$ comes from Kim–Roche [KR1998]; Talagrand [T1999] obtained an independent non-explicit upper bound.
 - There are several nearby variants, including the symmetric Ising perceptron, the spherical perceptron, and nonzero-margin perceptrons.
 
 ## References
 
-- [KM1989] Krauth, Werner; M\'ezard, Marc. "Storage capacity of memory networks with binary couplings." _Journal de Physique_ 50, no. 20 (1989): 3057--3066. DOI: [10.1051/jphys:0198900500200305700](https://doi.org/10.1051/jphys:0198900500200305700)
+- [KM1989] Krauth, Werner; Mézard, Marc. "Storage capacity of memory networks with binary couplings." _Journal de Physique_ 50, no. 20 (1989): 3057--3066. DOI: [10.1051/jphys:0198900500200305700](https://doi.org/10.1051/jphys:0198900500200305700)
 - [KR1998] Kim, Jeong Han; Roche, James R. "Covering Cubes by Random Half Cubes, with Applications to Binary Neural Networks." _Journal of Computer and System Sciences_ 56, no. 2 (1998): 223--252. DOI: [10.1006/jcss.1997.1560](https://doi.org/10.1006/jcss.1997.1560)
-- [T1999] Talagrand, Michel. "Intersecting random half cubes." _Random Structures & Algorithms_ 15, no. 3-4 (1999): 436--449. DOI: [10.1002/(SICI)1098-2418(199910/12)15:3/4<436::AID-RSA11>3.0.CO;2-5](https://doi.org/10.1002/(SICI)1098-2418(199910/12)15:3/4%3C436::AID-RSA11%3E3.0.CO;2-5)
+- [T1999] Talagrand, Michel. "Intersecting random half cubes." _Random Structures & Algorithms_ 15, no. 3-4 (1999): 436--449. DOI: [10.1002/(SICI)1098-2418(199910/12)15:3/4%3C436::AID-RSA11%3E3.0.CO;2-5](https://doi.org/10.1002/(SICI)1098-2418(199910/12)15:3/4%3C436::AID-RSA11%3E3.0.CO;2-5)
 - [X2021] Xu, Changji. "Sharp threshold for the Ising perceptron model." _The Annals of Probability_ 49, no. 5 (2021): 2399--2415. DOI: [10.1214/21-AOP1511](https://doi.org/10.1214/21-AOP1511)
 - [NS2023] Nakajima, Shuta; Sun, Nike. "Sharp threshold sequence and universality for Ising perceptron models." In _Proceedings of the 2023 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA)_, 638--674 (2023). DOI: [10.1137/1.9781611977554.ch28](https://doi.org/10.1137/1.9781611977554.ch28)
 - [AT2024] Altschuler, Dylan J.; Tikhomirov, Konstantin. "A note on the capacity of the binary perceptron." arXiv (2024), [arXiv:2401.15092](https://arxiv.org/abs/2401.15092)
@@ -53,4 +53,4 @@ Equivalently, $C_{80a}$ is the asymptotic storage-capacity / satisfiability thre
 
 ## Contribution notes
 
-- Used GPT5.4 Pro for a more in depth literature search.
+Prepared with assistance from GPT5.4 Pro for a more in-depth literature search.

--- a/constants/80a.md
+++ b/constants/80a.md
@@ -1,0 +1,56 @@
+# Ising perceptron capacity threshold
+
+## Description of constant
+
+Let $G = (g_{ij})$ be an $M \times N$ random matrix with independent standard Gaussian entries, and let
+$$
+Z(G) := \left| \left\{ \sigma \in \{-1,1\}^N : G \sigma \geq 0 \text{ coordinatewise} \right\} \right|.
+$$
+This is the zero-margin binary (or Ising) perceptron.  Write $M = \lfloor \alpha N \rfloor$.
+
+Define $C_{80a}$ to be the infimum of all $\alpha > 0$ such that
+$$
+\mathbb{P}(Z(G) > 0) \to 0 \qquad \text{as } N \to \infty.
+$$
+Equivalently, $C_{80a}$ is the asymptotic storage-capacity / satisfiability threshold of the zero-margin Ising perceptron.  Sharp-threshold results [X2021], [NS2023] show that this formulation captures the threshold location up to $o(1)$.
+
+## Known upper bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $<1$ | [KR1998] | Kim--Roche prove that the capacity is bounded away from $1$ with high probability. |
+| $0.9963$ | [KR1998] | Explicit combinatorial upper bound. |
+| $<1$ | [T1999] | Independent non-explicit upper bound of the form $1-\varepsilon$ for some $\varepsilon>0$. |
+| $0.847$ | [AT2024] | Complete proof of the upper bound outlined earlier by Krauth M\'ezard. |
+| $\alpha_{\star} \approx 0.833$ | [H2024] | Conditional on an explicit numerical maximization hypothesis for a two-variable function $\mathscr{S}_{\star}(\lambda_1,\lambda_2)$. |
+
+## Known lower bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $0$ | Trivial | |
+| $>0$ | [KR1998] | Shows the capacity is bounded away from zero with high probability. |
+| $\alpha_{\star} \approx 0.833$ | [DS2025], [NS2023] | Conditional on an explicit numerical maximization hypothesis for a one-variable function $\mathscr{S}_{\star}(\lambda)$; Ding--Sun prove the lower bound with positive probability, and the sharp-threshold theory of Nakajima--Sun upgrades this to with high probability for every $\alpha < \alpha_{\star}$. |
+
+## Additional comments
+
+- The physics prediction of Krauth--M\'ezard [KM1989] is that $C_{80a} = \alpha_{\star} \approx 0.833$.
+- The literature uses both the names _binary perceptron_ and _Ising perceptron_ for this model.
+- Huang [H2024], together with Ding--Sun [DS2025], gives a conditional proof of the Krauth M\'ezard prediction.
+- The explicit upper bound $0.9963$ comes from Kim--Roche [KR1998]; Talagrand [T1999] obtained an independent non-explicit upper bound.
+- There are several nearby variants, including the symmetric Ising perceptron, the spherical perceptron, and nonzero-margin perceptrons.
+
+## References
+
+- [KM1989] Krauth, Werner; M\'ezard, Marc. "Storage capacity of memory networks with binary couplings." _Journal de Physique_ 50, no. 20 (1989): 3057--3066. DOI: [10.1051/jphys:0198900500200305700](https://doi.org/10.1051/jphys:0198900500200305700)
+- [KR1998] Kim, Jeong Han; Roche, James R. "Covering Cubes by Random Half Cubes, with Applications to Binary Neural Networks." _Journal of Computer and System Sciences_ 56, no. 2 (1998): 223--252. DOI: [10.1006/jcss.1997.1560](https://doi.org/10.1006/jcss.1997.1560)
+- [T1999] Talagrand, Michel. "Intersecting random half cubes." _Random Structures & Algorithms_ 15, no. 3-4 (1999): 436--449. DOI: [10.1002/(SICI)1098-2418(199910/12)15:3/4<436::AID-RSA11>3.0.CO;2-5](https://doi.org/10.1002/(SICI)1098-2418(199910/12)15:3/4%3C436::AID-RSA11%3E3.0.CO;2-5)
+- [X2021] Xu, Changji. "Sharp threshold for the Ising perceptron model." _The Annals of Probability_ 49, no. 5 (2021): 2399--2415. DOI: [10.1214/21-AOP1511](https://doi.org/10.1214/21-AOP1511)
+- [NS2023] Nakajima, Shuta; Sun, Nike. "Sharp threshold sequence and universality for Ising perceptron models." In _Proceedings of the 2023 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA)_, 638--674 (2023). DOI: [10.1137/1.9781611977554.ch28](https://doi.org/10.1137/1.9781611977554.ch28)
+- [AT2024] Altschuler, Dylan J.; Tikhomirov, Konstantin. "A note on the capacity of the binary perceptron." arXiv (2024), [arXiv:2401.15092](https://arxiv.org/abs/2401.15092)
+- [H2024] Huang, Brice. "Capacity Threshold for the Ising Perceptron." In _2024 IEEE 65th Annual Symposium on Foundations of Computer Science (FOCS)_, 1126--1136 (2024). DOI: [10.1109/FOCS61266.2024.00074](https://doi.org/10.1109/FOCS61266.2024.00074); preprint at [arXiv:2404.18902](https://arxiv.org/abs/2404.18902)
+- [DS2025] Ding, Jian; Sun, Nike. "Capacity lower bound for the Ising perceptron." _Probability Theory and Related Fields_ 193, no. 3-4 (2025): 627--715. DOI: [10.1007/s00440-025-01364-x](https://doi.org/10.1007/s00440-025-01364-x)
+
+## Contribution notes
+
+- Used GPT5.4 Pro for a more in depth literature search.


### PR DESCRIPTION
So, I added constants/80a.md for the Ising perceptron capacity threshold, which I think is a really exciting problem at the boundary of probability, combinatorics, and theoretical machine learning.

Informally, this constant measures how many random constraints a binary perceptron can satisfy before solutions disappear. In other words, it is a sharp “capacity limit” for a simple neural-network-style model with binary weights.

This PR includes some of the older upper-bound history, the Krauth Mézard prediction which I thought is cool, and the more recent rigorous progress, while trying to clearly separate unconditional results from conditional bounds. I also added the corresponding row to README.md.

Let me know if anything else is needed or changes! I did use GPT5.4 Pro for help with a deeper literature study.