### PR TITLE
Update 68a: lower bound for Korenblum's constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [65](https://teorth.github.io/optimizationproblems/constants/65a.html) | Linnik's constant | 1 | 5 |
 | [66](https://teorth.github.io/optimizationproblems/constants/66a.html) | Elliott-Halberstam level-of-distribution exponent | $\frac{1}{2}$ | 1 |
 | [67](https://teorth.github.io/optimizationproblems/constants/67a.html) | Brennan's conjecture exponent | 3.422 | 4 |
-| [68](https://teorth.github.io/optimizationproblems/constants/68a.html) | Korenblum's constant | 0.28185 | 0.6778994 |
+| [68](https://teorth.github.io/optimizationproblems/constants/68a.html) | Korenblum's constant | 0.3554 | 0.6778994 |
 | [69](https://teorth.github.io/optimizationproblems/constants/69a.html) | Sendov radius constant | 1 | 2 |
 | [70](https://teorth.github.io/optimizationproblems/constants/70a.html) | Reverse Brunn-Minkowski constant | 1 | $<\infty$ |
 | [71](https://teorth.github.io/optimizationproblems/constants/71a.html) | Fourier Entropy-Influence constant | 6.278 | $\infty$ |

--- a/constants/68a.md
+++ b/constants/68a.md
@@ -39,16 +39,11 @@ where $\kappa$ is the largest constant for which this implication holds (often c
 The cited literature gives
 
 $$
-0.28185\ <\ \kappa\ <\ 0.6778994.
+0.3554\ <\ \kappa\ <\ 0.6778994.
 $$
 
 <a href="#CS2015-best-range">[CS2015-best-range]</a>
-
-Hence the best established range currently is
-
-$$
-0.28185\ <\ C_{68}\ <\ 0.6778994.
-$$
+[[Wang2025](#Wang2025)]
 
 ## Known upper bounds
 
@@ -62,7 +57,8 @@ $$
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 | $0$ |  | Trivial from $\kappa>0$. |
-| $0.28185$ | [[Wang2011](#Wang2011)] | Published numerical lower bound recorded in the survey literature. <a href="#CS2015-best-range">[CS2015-best-range]</a> |
+| $0.28185$ | [[Wang2011](#Wang2011)] | Published numerical lower bound recorded in the survey literature. <a href="#CS2015-best-range">[CS2015-best-range]</a>
+| $0.3554$ | [[Wang2025](#Wang2011)] | Published numerical lower bound.
 
 ## Additional comments and links
 
@@ -85,6 +81,8 @@ $$
 - <a id="Wang2008"></a>**[Wang2008]** Wang, Chunjie. *Domination in the Bergman space and Korenblum's constant.* Integral Equations and Operator Theory **61** (2008), 423-432. DOI: https://doi.org/10.1007/s00020-008-1587-4. [Google Scholar](https://scholar.google.com/scholar?q=Chunjie+Wang+Domination+in+the+Bergman+space+and+Korenblum%27s+constant)
 
 - <a id="Wang2011"></a>**[Wang2011]** Wang, Chunjie. *Some results on Korenblum's maximum principle.* Journal of Mathematical Analysis and Applications **373** (2011), 393-398. DOI: https://doi.org/10.1016/j.jmaa.2010.07.052. [Google Scholar](https://scholar.google.com/scholar?q=Chunjie+Wang+Some+results+on+Korenblum%27s+maximum+principle+JMAA+373+2011)
+
+- <a id="Wang2025"></a>**[Wang2025]** Wang, Chunjie. *A lower bound on Korenblum's constant.* Proceedings of the American Mathematical Society **153** (2025), 1209-1214. DOI: https://doi.org/10.1090/proc/17112. [Google Scholar](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C10&q=A+lower+bound+on+Korenblum%E2%80%99s+constant&btnG=)
 
 ## Contribution notes
 


### PR DESCRIPTION
In 68a, I updated the lower bound with a more recent paper. I also updated the README to reflect this. 