### PR TITLE
Add .env to .gitignore to prevent accidental credential exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 /drafts
 .DS_store
 /tmp


### PR DESCRIPTION
## Summary

This PR adds `.env` to the `.gitignore` file to help protect against accidental exposure of sensitive credentials.

`.env` files commonly store API tokens, GitHub tokens, and other secrets. Without this entry, a contributor could accidentally commit and push such a file, which could be exploited by malicious actors — for example, via techniques like the recently reported **ForceMemo** campaign (March 2026), which targets GitHub repositories by injecting backdoors after hijacking accounts.

## Change

```diff
+ .env
  /drafts
  .DS_store
  /tmp
```

This is a minimal, low-risk change with no impact on existing functionality.

Thank you for maintaining this project!