### PR TITLE
Add Wirsing constant (C_83): second eigenvalue of the GKW operator

### DIFF
--- a/constants/83a.md
+++ b/constants/83a.md
@@ -26,14 +26,14 @@ terms (attributed to Babenko) in the third edition.
 | ----- | --------- | -------- |
 | $2/(3+\sqrt{5}) \approx 0.38197$ | [Schweiger1980], cited in [MR1987] | Simple rigorous bound from metrical theory |
 | $0.30366327$ | [MR1987], eq. (5.20) | Certified via generalized Temple inequalities |
-| $0.30366300289873265859\!\ldots\!6424297 + 10^{-175}$ | [GKW2026] | Certified via interval arithmetic; 175-digit enclosure |
+| $0.30366300289873265859\!\ldots\!6424297 + 10^{-175}$ | [GKW2026] | Certified spectral enclosure for the infinite-dimensional GKW operator; 175 digits |
 
 ## Known lower bounds
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 | $0.30366299$ | [MR1987], eq. (5.20) | Certified via generalized Temple inequalities |
-| $0.30366300289873265859\!\ldots\!6424297 - 10^{-175}$ | [GKW2026] | Certified via interval arithmetic; 175-digit enclosure |
+| $0.30366300289873265859\!\ldots\!6424297 - 10^{-175}$ | [GKW2026] | Certified spectral enclosure for the infinite-dimensional GKW operator; 175 digits |
 
 ## Additional comments and links
 

--- a/constants/83a.md
+++ b/constants/83a.md
@@ -1,0 +1,71 @@
+# The Wirsing Constant
+
+## Description of constant
+
+The Gauss--Kuzmin--Wirsing (GKW) operator acts on suitable function spaces on $[0,1]$ by
+
+$$(\mathcal{L} f)(x) = \sum_{k=1}^\infty \frac{1}{(x+k)^2} f\!\left(\frac{1}{x+k}\right).$$
+
+This is the transfer operator of the Gauss map $T(x) = \{1/x\}$, which generates the continued fraction expansion.
+Its spectral radius is $1$, attained by the simple dominant eigenvalue $\lambda\_1 = 1$ (with eigenfunction proportional
+to the Gauss measure density $(1+x)^{-1}\log 2$). The subdominant eigenvalue $\lambda\_2$ is real and negative.
+
+The **Wirsing constant** $C\_{83}$ is defined as
+
+$$C\_{83} = \lvert \lambda\_2 \rvert \approx 0.3036630028987326586\ldots$$
+
+It controls the rate of convergence of the Gauss--Kuzmin distribution: the deviation of the distribution of
+the $n$-th continued-fraction partial quotient from its Gauss-measure limit decays like $C\_{83}^n$ as $n\to\infty$.
+The problem of determining $C\_{83}$ to high precision appears as Exercise 22 of Section 4.5.3 in the first
+edition of Knuth's *The Art of Computer Programming* (attributed to Gauss), and was reformulated in spectral
+terms (attributed to Babenko) in the third edition.
+
+## Known upper bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $2/(3+\sqrt{5}) \approx 0.38197$ | [Schweiger1980], cited in [MR1987] | Simple rigorous bound from metrical theory |
+| $0.30366327$ | [MR1987], eq. (5.20) | Certified via generalized Temple inequalities |
+| $0.30366300289873265859\!\ldots\!6424297 + 10^{-175}$ | [GKW2026] | Certified via interval arithmetic; 175-digit enclosure |
+
+## Known lower bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $0.30366299$ | [MR1987], eq. (5.20) | Certified via generalized Temple inequalities |
+| $0.30366300289873265859\!\ldots\!6424297 - 10^{-175}$ | [GKW2026] | Certified via interval arithmetic; 175-digit enclosure |
+
+## Additional comments and links
+
+- The second eigenvalue satisfies $\lambda\_2 < 0$, so $C\_{83} = -\lambda\_2$.
+- Prior to [GKW2026], high-precision *non-certified* numerical estimates were widely available: Wirsing [Wirsing1974]
+  gave 20 digits (with the caveat, noted in [MR1987], that it was unclear how many could be trusted); MacLeod [MacLeod1993]
+  gave approximately 14 digits via Chebyshev extrapolation; Flajolet--Vallée [FV1994] gave approximately 30 digits;
+  Briggs [Briggs2003] computed 385 digits; and by 2012, over 480 digits had been computed non-rigorously [Alkauskas2012].
+- [GKW2026] also certifies the next 49 eigenvalues of the GKW operator, each to at least 90 decimal digits,
+  together with the associated eigenvectors and Riesz spectral projectors.
+- The full 175-digit center value is
+  $\tilde\lambda\_2 = -0.30366\,30028\,98732\,65859\,74481\,21901\,55623\,31108\,77352\,25365$
+  $78951\,88245\,48146\,72269\,95294\,24691\,09843\,40811\,93436\,36368$
+  $11098\,27226\,37106\,16938\,47461\,48597\,45801\,31606\,52653\,81818$
+  $23787\,91324\,46139\,89647\,64297$,
+  with $\lvert\lambda\_2 - \tilde\lambda\_2\rvert < 10^{-175}$.
+- The GKW operator is compact on Hardy spaces $H^\infty(D)$ for suitable complex discs $D \supset [0,1]$; the full spectrum is discrete and real.
+- [Wikipedia page on the Gauss--Kuzmin--Wirsing operator](https://en.wikipedia.org/wiki/Gauss%E2%80%93Kuzmin%E2%80%93Wirsing_operator)
+- Code: [orkolorko/GKWExperiments.jl](https://github.com/orkolorko/GKWExperiments.jl); Data: [Harvard Dataverse, doi:10.7910/DVN/HKM3Y2](https://doi.org/10.7910/DVN/HKM3Y2)
+
+## References
+
+- [Alkauskas2012] Alkauskas, Giedrius. Transfer operator for the Gauss' continued fraction map. I. Structure of the eigenvalues and trace formulas. arXiv:1210.4083 (2012/2018).
+- [Briggs2003] Briggs, Keith. A precise computation of the Gauss--Kuzmin--Wirsing constant. Unpublished (2003). Available at http://keithbriggs.info/documents/wirsing.pdf.
+- [FV1994] Flajolet, Philippe and Vallée, Brigitte. Continued fraction algorithms, functional operators, and structure constants. *Theoret. Comput. Sci.* 194 (1-2) (1998), 1--34.
+- [GKW2026] Nisoli, Isaia. Certified spectral approximation of transfer operators and the Gauss map. Preprint (2026). [arXiv:2602.19435](https://arxiv.org/abs/2602.19435).
+- [MacLeod1993] MacLeod, A. J. High-accuracy numerical values in the Gauss--Kuz'min continued fraction problem. *Comput. Math. Appl.* 26 (3) (1993), 37--44.
+- [MR1987] Mayer, Dieter and Roepstorff, Gert. On the relaxation time of Gauss's continued-fraction map. I. The Hilbert space approach (Koopmanism). *J. Statist. Phys.* 47 (1--2) (1987), 149--171.
+- [Schweiger1980] Schweiger, Fritz. The metrical theory of the Jacobi--Perron algorithm. *Lecture Notes in Mathematics*, No. 334. Springer, Berlin, 1980.
+- [Wirsing1974] Wirsing, Eduard. On the theorem of Gauss--Kuzmin--Lévy and a Frobenius-type theorem for function spaces. *Acta Arith.* 24 (1974), 507--528. [doi:10.4064/aa-24-5-507-528](https://doi.org/10.4064/aa-24-5-507-528)
+
+## Contribution notes
+
+Claude Code (claude-sonnet-4-6) was used to assist in researching the historical bounds and preparing this submission.
+All references and mathematical content were reviewed and verified by the author.


### PR DESCRIPTION
## Summary

- Proposes a new entry $C_{83}$ for the **Wirsing constant** $|\lambda_2|$, the absolute value of the subdominant eigenvalue of the Gauss--Kuzmin--Wirsing (GKW) transfer operator.
- This constant controls the exponential rate of convergence of the Gauss--Kuzmin distribution in the continued fraction expansion, and has been studied since Wirsing (1974).
- Prior certified enclosures covered only 6 significant digits (Mayer--Roepstorff 1987, via generalized Temple inequalities). The new result [arXiv:2602.19435] gives a **175-digit certified enclosure** via a rigorous a posteriori spectral enclosure for a regularizing infinite-dimensional operator, reducing the certification to validated finite-dimensional linear algebra.

## Fit with repository scope

The constant has a large existing literature, is actively studied, and is amenable to computational approaches for both upper and lower bounds — the defining criteria for inclusion. The "optimization" problem is to determine $|\lambda_2|$ to as many certified decimal places as possible.

## Test plan

- [ ] Check LaTeX renders correctly on the site
- [ ] Verify all references are accessible
- [ ] Confirm constant number 83 is not already claimed (largest existing entry was C_82 at time of submission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)