### PR TITLE
Update 82a.md

### DIFF
--- a/constants/82a.md
+++ b/constants/82a.md
@@ -12,9 +12,8 @@ The Zhang-Zagier height is the function
 
 $$h_Z : \overline{\mathbb{Q}} \rightarrow \mathbb{R}, \quad h_Z(\alpha)=h(\alpha)+h(1-\alpha).$$
 
-The **essential minimum of the Zhang-Zagier height** is the smallest number $C\_{82}$ such that there exists a finite set
-$S\subseteq \overline{\mathbb{Q}}$ with the property that the inequality $h_Z(\alpha)\geq C\_{82}$ holds for all
-$\alpha \in \overline{\mathbb{Q}}\setminus S$.
+The **essential minimum of the Zhang-Zagier height** is the supremum $C\_{82}$ over all real numbers $H$ such that the set $\{\alpha \in \overline{\mathbb{Q}} |
+h_Z(\alpha)\le H\}$ is finite.
 
 ## Known upper bounds
 


### PR DESCRIPTION
The definition is wrong as stated (C_{82} would have been trivially -\infty). Here is the correct definition.