### PR TITLE
Updated 10a Grothendieck real constant lower bound

### DIFF
--- a/constants/10a.md
+++ b/constants/10a.md
@@ -41,7 +41,7 @@ $u_{i},v_{j} \in S^{d-1}$ for some sufficiently large finite dimension $d$).
 
 ## Additional comments and links
 
-- Krivine conjectured that $C_{10} = \frac{\pi}{2\ln(1+\sqrt{2})}$, but this was disproved in [BMMN2011] by showing the inequality is strict.
+- Krivine conjectured that $C_{10} = \frac{\pi}{2\ln(1+\sqrt{2})}$, but this was disproved in [BMMN2011] by showing the inequality is strict.  It seems that [BMMN2011] proves that $K_{G}< C_{10} - 10^{-500}$.
 - A standard reference survey is [Pis2012].
 - [Wikipedia page on the Grothendieck inequality](https://en.wikipedia.org/wiki/Grothendieck_inequality)
 - The strategy of [Hei26] could possibly be used to improve the complex Grothendieck constant lower bound.

--- a/constants/10a.md
+++ b/constants/10a.md
@@ -36,19 +36,22 @@ $u_{i},v_{j} \in S^{d-1}$ for some sufficiently large finite dimension $d$).
 | ----- | --------- | -------- |
 | $1$ | Trivial | Follows from the definitions |
 | $\dfrac{\pi}{2} \approx 1.57080$ | [G1953] | Grothendieck’s original lower bound |
-| $1.67696$ | [Dav1984], [Ree1991] | Best known lower bound (due to Davie and independently Reeds) |
+| $1.67696\ldots$ | [Dav1984], [Ree1991] | (due to Davie and independently Reeds) |
+| $1.67696\ldots + 10^{-26}$ | [Hei26] | Best known lower bound |
 
 ## Additional comments and links
 
 - Krivine conjectured that $C_{10} = \frac{\pi}{2\ln(1+\sqrt{2})}$, but this was disproved in [BMMN2011] by showing the inequality is strict.
 - A standard reference survey is [Pis2012].
 - [Wikipedia page on the Grothendieck inequality](https://en.wikipedia.org/wiki/Grothendieck_inequality)
+- The strategy of [Hei26] could possibly be used to improve the complex Grothendieck constant lower bound.
 
 ## References
 
-- [BMMN2011] Braverman, Mark; Makarychev, Konstantin; Makarychev, Yury; Naor, Assaf. *The Grothendieck constant is strictly smaller than Krivine's bound.* (2011). [arXiv:1103.6161](https://arxiv.org/abs/1103.6161)
+- [BMMN2011] Braverman, Mark; Makarychev, Konstantin; Makarychev, Yury; Naor, Assaf. *The Grothendieck constant is strictly smaller than Krivine's bound.* Forum of Mathematics, Pi, Volume 1, 2013, e4. [arXiv:1103.6161](https://arxiv.org/abs/1103.6161)
 - [Dav1984] Davie, A. M. *Lower bound for $K_{G}$.* Unpublished note (1984).
 - [G1953] Grothendieck, Alexandre. *Résumé de la théorie métrique des produits tensoriels topologiques.* Bol. Soc. Mat. São Paulo **8** (1953), 1–79.
+- [Hei26] Heilman, Steven. *A lower bound for Grothendieck's constant.* (2026) [arXiv:2603.22616](https://arxiv.org/abs/2603.22616)
 - [K1979] Krivine, Jean-Louis. *Constantes de Grothendieck et fonctions de type positif sur les sphères.* Advances in Mathematics **31** (1979), 16–30.
 - [Pis2012] Pisier, Gilles. *Grothendieck’s theorem, past and present.* Bull. Amer. Math. Soc. (N.S.) **49** (2012), 237–323. [arXiv:1101.4195](https://arxiv.org/abs/1101.4195)
 - [Ree1991] Reeds, James A. *A new lower bound on the real Grothendieck constant.* Unpublished manuscript (1991).


### PR DESCRIPTION
Added a new lower bound for the real Grothendieck constant with citation https://arxiv.org/abs/2603.22616 .  
Added comment that this strategy could possibly apply to the complex Grothendieck constant lower bound.
Added comment about making the upper bound from BMMN more explicit.