### PR TITLE
Improve C47 upper bound from 9 to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |
 | [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490341088858244 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
-| [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 9 |
+| [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 4 |
 | [48](https://teorth.github.io/optimizationproblems/constants/48a.html) | One-dimensional convex sub-Gaussian comparison constant | $\approx 5.33386$ | $\approx 5.33386$ |
 | [49](https://teorth.github.io/optimizationproblems/constants/49a.html) | Erdős–Szemerédi $3$-sunflower-free capacity | >1.551 ($\geq 1.554*$) | $\frac{3}{2^{2/3}} \approx 1.88988$ |
 | [50](https://teorth.github.io/optimizationproblems/constants/50a.html) | Approximation ratio for quantum Max Cut | 0.611 | $<1$ (0.5 for product states) |

--- a/constants/47a.md
+++ b/constants/47a.md
@@ -32,7 +32,8 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $9$ | <a href="#Tao2006">[Tao2006]</a> | The standard covering-lemma proof gives an explicit constant $3^d$ in the weak-type $(1,1)$ inequality, and the same argument applies to cubes; hence $c_2\le 3^2=9$. <a href="#Tao2006-weak-3d">[Tao2006-weak-3d]</a> <a href="#Tao2006-cubes">[Tao2006-cubes]</a> |
+| $4$ | [Tao2010] | The Vitali-covering proof can be sharpened from $3^d$ to $2^d$ by covering centers with $(2+\varepsilon)$-dilates of a disjoint subcollection and letting $\varepsilon\downarrow 0$. The same argument applies to $\ell_\infty$ balls, i.e. axis-parallel cubes; hence $c_2\le 2^2=4$. [Tao2010-ex42] |
+| $9$ | [Tao2006] | The standard covering-lemma proof gives an explicit constant $3^d$ in the weak-type $(1,1)$ inequality, and the same argument applies to cubes; hence $c_2\le 3^2=9$. [Tao2006-weak-3d] [Tao2006-cubes] |
 
 ## Known lower bounds
 
@@ -83,6 +84,11 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 	  **loc:** arXiv PDF p.3, Introduction (equation (1.8) and the following sentence).  
 	  **quote:** “Hence (1.8) $C=\frac{11+\sqrt{61}}{12}=1.5675208\ldots$ is the largest solution of the quadratic equation (1.9) $12C^2-22C+5=0$.”
 
+- **[Tao2010]** Tao, Terence. *245A, Notes 5: Differentiation theorems.* What's new, 16 October 2010. [Blog post](https://terrytao.wordpress.com/2010/10/16/245a-notes-5-differentiation-theorems/).
+- **[Tao2010-ex42]**
+  **loc:** Exercise 42.
+  **quote:** “Improve the constant $3^d$ in the Hardy-Littlewood maximal inequality to $2^d$.”
+
 - <a id="Tao2006"></a>**[Tao2006]** Tao, Terence. *247A Notes 3: Maximal theorem of Hardy-Littlewood.* Lecture notes (Fall 2006). [Google Scholar](https://scholar.google.com/scholar?q=Tao+247A+Notes+3+Maximal+theorem+of+Hardy-Littlewood). [Author PDF](https://www.math.ucla.edu/~tao/247a.1.06f/notes3.pdf)
 	- <a id="Tao2006-weak-3d"></a>**[Tao2006-weak-3d]**  
 	  **loc:** Author PDF (`notes3.pdf`) p.3, end of proof of Theorem 1.2.  
@@ -94,3 +100,4 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 ## Contribution notes
 
 Prepared with assistance from ChatGPT 5.2 Pro.
+This update was prepared with assistance from GPT-5.5 Pro; citations and mathematical details were reviewed by the human contributor.


### PR DESCRIPTION
This PR improves the known upper bound for C_47, the centered Hardy–Littlewood maximal constant in dimension 2 for axis-parallel squares, from 9 to 4.

The current entry uses the standard Vitali covering proof with constant 3^d, giving 9 in dimension 2. Tao's 245A differentiation notes, Exercise 42, state the standard refinement from 3^d to 2^d. Applying this in dimension 2 gives c_2 <= 2^2 = 4.

The same argument applies to l_infty balls, i.e. axis-parallel cubes/squares, since the covering step only uses dilation and volume scaling.

AI assistance note: this update was prepared with help from GPT-5.5 Pro; I checked the cited Tao source.