### PR TITLE
Add 84a: finite-jet norm-equivalence constant for Leray-projected point jets on T^d

### DIFF
--- a/constants/84a.md
+++ b/constants/84a.md
@@ -1,0 +1,142 @@
+# The Finite-Jet Norm-Equivalence Constant
+
+## Description of constant
+
+For integers $m \geq 0$, $d \geq 2$, and $s > m + d/2$, consider the family
+of Leray-projected point jets
+
+$$F\_{(\beta,j)} = \mathbb{P}\,\partial^\beta\bigl(\delta\_0 \, e\_j\bigr) \in H^{-s}(\mathbb{T}^d),
+\qquad \lvert\beta\rvert \leq m,\ j = 1,\ldots,d,$$
+
+on the torus $\mathbb{T}^d = \mathbb{R}^d/(2\pi\mathbb{Z})^d$, where $\mathbb{P}$
+is the Leray projector onto divergence-free vector fields. The raw family is
+overcomplete: the projected gradient relations
+
+$$\mathbb{P}\,\nabla \partial^\gamma \delta\_0 = 0,\qquad \lvert\gamma\rvert \leq m-1,$$
+
+give an exact kernel of dimension $\binom{m+d-1}{d}$ in the raw coefficient space.
+The *finite-jet norm-equivalence constant* $C\_{m,s,d}$ is defined by the
+quotient norm equivalence
+
+$$C\_{m,s,d} = \sup\_{F \neq 0} \frac{\lVert A \rVert\_{\ell^2\_{\min}}}{\lVert F \rVert\_{H^{-s}(\mathbb{T}^d)}},
+\qquad F = \sum\_{\beta,j} A\_{(\beta,j)} F\_{(\beta,j)},$$
+
+where $\lVert A \rVert\_{\ell^2\_{\min}}$ is the minimum Euclidean norm among
+coefficient vectors representing $F$ (equivalently, the Euclidean norm of the
+canonical representative in the quotient by the gradient kernel). The reciprocal
+of $C\_{m,s,d}^2$ is the smallest positive eigenvalue of the Fourier-side Gram
+matrix
+
+$$G\_{(\beta,j),(\beta',j')}
+  = \sum\_{k \in \mathbb{Z}^d \setminus \{0\}}
+    (1+\lvert k\rvert^2)^{-s}
+    (ik)^\beta \overline{(ik)^{\beta'}}
+    \bigl(\delta\_{jj'} - k\_j k\_{j'} / \lvert k\rvert^2\bigr).$$
+
+The threshold $s = m + d/2$ is not admissible: at this value the top-order
+lattice sums diverge logarithmically.
+
+This page treats the *quintessential* case
+
+$$C\_{84} := C\_{3,5,3},$$
+
+which is the natural representative for the 3D incompressible Navier-Stokes
+and Oseen-controllability application: $(m, d) = (3, 3)$ captures cubic point
+jets in physical dimension three while leaving a $50$-dimensional quotient
+small enough for explicit $W(B\_3)$ sector decomposition, and $s = 5$ is the
+smallest stable benchmark with a half-derivative buffer above the threshold
+$s = 9/2$. Variants for other $(m, s)$ are recorded in Additional comments
+below.
+
+## Known upper bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $6.66760093$ | [Mathews2026] | Cube truncation at $\lvert k\_i\rvert \leq K = 50$; rigorous in Loewner order. |
+| $6.59846649$ | [Mathews2026] | Cube truncation at $K = 200$. |
+| $6.576432995517075$ | [Mathews2026] | mpmath Ewald/Mellin evaluator with analytic truncation bounds at precision 80, treating mpmath's quadrature as exact at the working precision (validated by precision-doubling and the $m = 0$ closed form). |
+
+## Known lower bounds
+
+| Bound | Reference | Comments |
+| ----- | --------- | -------- |
+| $6.53538338$ | [Mathews2026] | Cube + Rayleigh-tail certificate (AM-GM pointwise polynomial bound on the $K = 50$ cube minimizer, Euclidean inflated-cube tail integral). |
+| $6.576432995516946$ | [Mathews2026] | mpmath Ewald lower bound (same engineering-rigorous evaluator as above). |
+
+## Additional comments and links
+
+**Quotient structure.** The kernel theorem $\ker \Phi\_m = \operatorname{span}\{\mathbb{P}\nabla \partial^\gamma \delta\_0 : \lvert\gamma\rvert \leq m-1\}$ has a Fourier-side proof: the constraint $\mathbb{P} P\_A = 0$ at every nonzero lattice point gives $P\_A(k) \parallel k$ on $\mathbb{Z}^d \setminus \{0\}$, and Zariski density of $\mathbb{Z}^d \setminus \{0\}$ in $\mathbb{C}^d$ upgrades this to a polynomial identity. For $(m, d) = (3, 3)$ the raw dimension is $60$, the kernel dimension is $\binom{5}{3} = 10$, and the quotient dimension is $50$.
+
+**Parity splitting.** Central inversion $k \to -k$ commutes with the Gram, giving an exact even-odd parity decomposition. For $(m, d) = (3, 3)$ the quotient blocks have dimensions $18$ (even, grades $0$ and $2$) and $32$ (odd, grades $1$ and $3$); the minimizer at $s = 5$ lies in the odd block, so the absence of grades $0$ and $2$ from the minimizer is forced by symmetry rather than numerical roundoff.
+
+**$W(B\_3)$ sector decomposition and sector crossing.** The full hyperoctahedral group $W(B\_3) = (\mathbb{Z}\_2)^3 \rtimes S\_3$ of signed permutations of $\mathbb{R}^3$ also commutes with the Gram. The $50$-dimensional quotient decomposes into nine $W(B\_3)$ isotypic components, two of which can contain the smallest positive eigenvalue depending on $s$:
+
+- *Block 0* (above crossing): the isotypic component of the $S\_3$ standard $2$D irrep lifted trivially to $(\mathbb{Z}\_2)^3$, with multiplicity $3$ inside the quotient. Its $3 \times 3$ multiplicity-space Gram has eigenvalues given in closed form by the trigonometric Cardano formula. Six independent lattice-sum entries enter.
+
+- *Block 1* (below crossing): the isotypic component of the irrep "natural $3$D rep tensor $\operatorname{sgn}(\sigma)$" with multiplicity $2$. Its $2 \times 2$ multiplicity-space Gram has eigenvalues in closed form
+
+  $$\lambda\_-^{(1)} = \tfrac{1}{6}W(s) - 3D(s) - \tfrac{1}{2}\sqrt{\bigl(\tfrac{W(s)}{3} - 4B(s)\bigr)^2 + 4\bigl(3D(s) - B(s)\bigr)^2},$$
+
+  with
+
+  $$W(s) = Z(s-2) - 2Z(s-1) + Z(s) = \sum\_{k \neq 0} \lvert k\rvert^4 (1+\lvert k\rvert^2)^{-s},$$
+  $$B(s) = \sum\_{k \neq 0} k\_1^2 k\_2^2 (1+\lvert k\rvert^2)^{-s},$$
+  $$D(s) = \sum\_{k \neq 0} k\_1^4 k\_2^2 (1+\lvert k\rvert^2)^{-s} / \lvert k\rvert^2,$$
+  $$Z(s) = \sum\_{k \neq 0} (1+\lvert k\rvert^2)^{-s}.$$
+
+  Two structural identities collapse the original four lattice-sum entries to this minimal form: the trace identity $3A + 6B = W$ (from $\sum \lvert k\rvert^2 (1+\lvert k\rvert^2)^{-s} = Z(s-1) - Z(s)$) and the orbit identity $2D + C = B$ (from $k\_1^2 k\_2^2 \lvert k\rvert^2 = k\_1^4 k\_2^2 + k\_1^2 k\_2^4 + k\_1^2 k\_2^2 k\_3^2$), where $A = \sum k\_1^4 w$ and $C = \sum k\_1^2 k\_2^2 k\_3^2 w / \lvert k\rvert^2$ are eliminated. The anisotropic content of the constant below the crossing is therefore exactly two scalar lattice moments $B$, $D$ plus three Sobolev-zeta values $Z(s-2)$, $Z(s-1)$, $Z(s)$.
+
+- *Sector crossing.* The two lead blocks switch dominance at
+
+  $$s^\* \approx 4.7892803103,
+  \qquad \lambda\_{\min}^+(G\_{3,s^\*,3}) \approx 0.0383102507,
+  \qquad C\_{3,s^\*,3} \approx 5.109077647.$$
+
+  For $s \in (9/2, s^\*)$ the constant equals $1/\sqrt{\lambda\_-^{(1)}(s)}$ (block 1, $2 \times 2$ quadratic form). For $s > s^\*$ it equals $1/\sqrt{\lambda\_-^{(0)}(s)}$ (block 0, $3 \times 3$ trigonometric Cardano form). The crossing exponent itself is determined by the transcendental equation $\lambda\_-^{(0)}(s) = \lambda\_-^{(1)}(s)$.
+
+**$m = 0$ closed form.** For $m = 0$, the Gram is isotropic, $G = \tfrac{2}{3} Z\_d(s) I\_d$, and
+
+$$C\_{0,s,d} = \sqrt{d / ((d-1)Z\_d(s))}.$$
+
+For $(d, s) = (3, 5)$ this gives $C\_{0,5,3} = \sqrt{3/(2 Z\_3(5))} \approx 2.439\ldots$. The cube truncation converges to this closed form at rate $O(K^{d - 2s})$, providing a calibration of the truncation methodology.
+
+**Variants.** The same construction with $s \neq 5$ gives a one-parameter family of related constants. Selected mpmath-Ewald values:
+
+| $(m,d,s)$ | $C\_{m,s,d}$ (engineering-rigorous, ${\sim}10^{-13}$ width) | Lead $W(B\_3)$ block |
+| --- | --- | --- |
+| $(3,3,5.0)$ | $6.576432995516\ldots517$ | block 0 (above crossing) |
+| $(3,3,4.75)$ | $4.923777057473\ldots$ | block 1 (below crossing) |
+| $(3,3,4.6)$ | $4.249762005328\ldots329$ | block 1 (below crossing) |
+
+The above-crossing single-grade vs below-crossing mixed-grade distinction explains a sharp gap collapse from ${\sim}1\%$ to ${\sim}0.002\%$ in the cube + Rayleigh-tail certificate as $s$ moves from $5$ toward the threshold $9/2^+$; the slowest tail integrand changes from $t^{8 - 2s}$ (mixed-grade) to $t^{6 - 2s}$ (pure-grade-2).
+
+**Cross-domain applications.** The constant has natural interpretations in several active research lines:
+
+- Parabolic controllability with point-supported terminal data: the terminal-symbol factor in adjoint observability estimates with finite-jet terminal data has the form $\lVert F\_\alpha \rVert\_{H^{-s}} \geq c\_{\mathrm{term}} \lvert\alpha\rvert$, with $c\_{\mathrm{term}}$ controlled by $1/C\_{m,s,d}$.
+- Inf-sup (Babuska-Brezzi) analysis for divergence-free finite element methods: discrete analogs of $C\_{m,s,d}$ control the well-posedness of divergence-constrained variational forms.
+- Off-the-grid sparse divergence-free measure recovery via atomic-norm minimization: $C\_{m,s,d}$ is a coherence parameter for divergence-free atomic dictionaries built from point-supported jets.
+- $H^{-s}$ norm equivalence on point-supported momenta in LDDMM-style diffeomorphic image registration: the registration energy is $\lVert p \rVert^2\_{H^{-s}}$ with $p$ a point-momentum measure, and the squared coefficient norm is controlled by $C\_{m,s,d}^2$.
+
+Existing literature in each of these uses related quantities implicitly without pinning down values; the closed-form expressions, kernel theorem, and $W(B\_3)$ sector-crossing observation in this submission are not yet recorded in any of them.
+
+**Live optimization targets.**
+
+1. Strict Arb-rigor for the engineering-rigorous Ewald evaluator: replace mpmath's quadrature with a provable Gauss-Legendre / tanh-sinh scheme with rigorous Lagrange remainder bounds. The mpmath Ewald row above is engineering-rigorous (every truncation has an explicit analytic bound, mpmath quadrature treated as exact at the working precision and validated by precision-doubling), but not yet strictly Arb-rigorous.
+2. Higher-precision two-sided certified brackets approaching the threshold regime $s \to 9/2^+$, where the closed-form $W(B\_3)$ structure simplifies but the cube convergence rate degrades.
+3. A closed-form analytic eigenvalue inside one of the $W(B\_3)$ multiplicity-space Gram blocks would eliminate the trigonometric Cardano root (in the above-crossing block) or further reduce the two-anisotropic-moment dependence (in the below-crossing block) to elementary expressions in known Sobolev/Epstein zetas.
+
+This constant is recorded here under the "particular mathematical interest" exception clause of the contributing guidelines. The four cross-domain applications above and the explicit closed-form $W(B\_3)$ sector structure are the basis.
+
+## References
+
+- [Mathews2026] R. J. Mathews. Finite-jet norm-equivalence constants for Leray-projected point jets on $\mathbb{T}^d$: closed-form $W(B\_3)$ sector decomposition. Preprint and companion scripts (2026). [Code repository](https://github.com/kantrarian/finite-jet-constants).
+
+## Contribution notes
+
+Claude (Anthropic Claude Code, Opus 4.7) was used to assist with the
+representation-theoretic decomposition, the closed-form $W(B\_3)$ block-0 and
+block-1 multiplicity-Gram eigenvalue extraction, the moment-reduction identities,
+and the drafting of this submission. All mathematical content (kernel theorem,
+sector-crossing exponent, closed-form expressions, numerical brackets) was
+reviewed and verified by the human contributor against independent cube and
+Ewald computations.


### PR DESCRIPTION
## Summary

Adds `constants/84a.md` for the finite-jet norm-equivalence constant $C_{84} := C_{3,5,3}$ on $\mathbb{T}^3$. The constant is the reciprocal-square-root of the smallest positive eigenvalue of the Fourier-side Gram matrix for Leray-projected cubic point jets at Sobolev exponent $s = 5$. The page treats the quintessential $(m,d,s) = (3,3,5)$ case and lists variants for $s \in \{4.6, 4.75\}$ in the Additional comments, per the family-with-variants guidance in CONTRIBUTING.md.

Key structural results recorded:

- Kernel theorem fixing the quotient dimension as $50 = 60 - 10$ via the projected-gradient relations $\mathbb{P}\nabla\partial^\gamma \delta_0 = 0$.
- $W(B_3)$ hyperoctahedral sector decomposition: the smallest positive eigenvalue admits a piecewise closed form — a $2 \times 2$ quadratic below the sector crossing at $s^* \approx 4.7892803103$ and a $3 \times 3$ trigonometric Cardano above it.
- Trace identity $3A + 6B = Z(s-2) - 2Z(s-1) + Z(s)$ and orbit identity $2D + C = B$ that reduce the below-crossing closed form to three Sobolev-zeta shifts plus two anisotropic moments.
- Classical certified bracket $[6.53538338, 6.59846649]$ (cube + Rayleigh-tail, fully classical except for double-precision linear algebra).
- Engineering-rigorous mpmath Ewald bracket $[6.576432995516946, 6.576432995517075]$ with explicit analytic truncation bounds and precision-doubling cross-validation.

Companion scripts (cube truncation, Rayleigh-tail certificate, mpmath Ewald, $W(B_3)$ block decomposition, closed-form eigenvalue extraction, sector-crossing bisection) are at https://github.com/kantrarian/finite-jet-constants.

## Why this is in scope

The constant depends on three parameters $(m, s, d)$, which would ordinarily fail the no-additional-parameters criterion. I am submitting it under the "particular mathematical interest" exception clause for the following reasons:

1. **Parabolic controllability with point-supported terminal data** (Imanuvilov, Coron, Le Rousseau, Fernandez-Cara line): $1/C_{m,s,d}$ controls the terminal-symbol constant $c_{\text{term}}$ in adjoint observability estimates.
2. **Inf-sup / Babuska-Brezzi analysis for divergence-free FEM** (Bramble-Pasciak, Boffi-Brezzi-Fortin, Schoberl, Falk, Neilan): discrete analogs of $C_{m,s,d}$ control well-posedness; the continuous-side benchmark is what existing literature uses implicitly without pinning down values.
3. **Off-the-grid sparse divergence-free measure recovery / atomic-norm minimization** (Candes-Fernandez-Granda, De Castro-Gamboa, Duval-Peyre, Bredies-Pikkarainen): $C_{m,s,d}$ is a coherence parameter for divergence-free atomic dictionaries.
4. **$H^{-s}$ norm equivalence on point-supported momenta in LDDMM** (Trouve, Younes, Miller, Pennec): registration energy is $\|p\|_{H^{-s}}^2$, controlled by $C_{m,s,d}^2$.

The kernel theorem, the certified two-sided bracket, the $W(B_3)$ sector-crossing observation, and the piecewise closed form for $\lambda_{\min}^+$ are, to the best of my knowledge, not yet recorded in any of these four lines. If the maintainers prefer literature to exist before this is recorded, or prefer an issue-first discussion, I am happy to convert or withdraw.

## Test plan

- [x] File placed at `constants/84a.md`, follows `template.md` six-section structure.
- [x] Constant numbered `84a`: highest existing was `83a` at time of this PR.
- [x] All inline LaTeX uses `\_` and `\lvert/\rvert` (no `_` or `|` inside `$...$`).
- [x] Companion scripts at https://github.com/kantrarian/finite-jet-constants compile (`python -m py_compile`) and reproduce the numerical brackets in the file.
- [x] AI assistance disclosed in Contribution notes (Anthropic Claude Code, Opus 4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)