### PR TITLE
Update C47 lower bound using Aldaz 2000

### DIFF
--- a/constants/47a.md
+++ b/constants/47a.md
@@ -39,6 +39,7 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
+| $\dfrac{3}{4}-\dfrac{\sqrt{2}}{4}+\dfrac{\sqrt{6}}{2}\approx 1.6211915$ | [Ald2000] | Aldaz's Proposition 1.4 gives a lower bound in every dimension $n\ge 2$. Specializing the formula to $n=2$ gives the displayed value. [Ald2000-prop1.4] |
 | $\dfrac{11+\sqrt{61}}{12}\approx 1.5675208$ | <a href="#Mel2003">[Mel2003]</a>, <a href="#Ald2011">[Ald2011]</a> | Melas proved $c_1=\dfrac{11+\sqrt{61}}{12}$. Since $c_{d+1}\ge c_d$, we get $c_2\ge c_1$. <a href="#Mel2003-c1-formula">[Mel2003-c1-formula]</a> <a href="#Ald2011-monotone">[Ald2011-monotone]</a> |
 
 ## Additional comments and links
@@ -55,6 +56,9 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 - [Wikipedia page on the Hardy–Littlewood maximal function](https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function)
 
 ## References
+
+- **[Ald2000]** Aldaz, José M. *A remark on the centered $n$-dimensional Hardy-Littlewood maximal function.* Czechoslovak Mathematical Journal **50** (2000), no. 1, 103-112. MR 1745465. [DML-CZ](https://dml.cz/handle/10338.dmlcz/127554). [PDF](https://dml.cz/bitstream/handle/10338.dmlcz/127554/CzechMathJ_50-2000-1_14.pdf).
+- **[Ald2000-prop1.4]** **loc:** p. 110, Proposition 1.4. **note:** Specializing Aldaz's formula to $n=2$ gives $\dfrac{3}{4}-\dfrac{\sqrt{2}}{4}+\dfrac{\sqrt{6}}{2}$.
 
 - <a id="Ald2011"></a>**[Ald2011]** Aldaz, José M. *The weak type (1,1) bounds for the maximal function associated to cubes grow to infinity with the dimension.* Annals of Mathematics (2) **173** (2011), no. 2, 1013–1023. DOI: [10.4007/annals.2011.173.2.10](https://doi.org/10.4007/annals.2011.173.2.10). [Google Scholar](https://scholar.google.com/scholar?q=The+weak+type+(1%2C1)+bounds+for+the+maximal+function+associated+to+cubes+grow+to+infinity+with+the+dimension+Aldaz). [arXiv PDF](https://arxiv.org/pdf/0805.1565.pdf)
 	- <a id="Ald2011-cd-infty"></a>**[Ald2011-cd-infty]**  


### PR DESCRIPTION
Updates the lower bound for C47 using Proposition 1.4 of José M. Aldaz, *A remark on the centered n-dimensional Hardy-Littlewood maximal function*.

Paper: https://dml.cz/handle/10338.dmlcz/127554  
PDF: https://dml.cz/bitstream/handle/10338.dmlcz/127554/CzechMathJ_50-2000-1_14.pdf

Substituting n = 2 in Aldaz's lower bound gives

$$
c_2 \ge \frac{3}{4} - \frac{\sqrt{2}}{4} + \frac{\sqrt{6}}{2}
= 1.6211914808\ldots .
$$

This improves the currently listed lower bound

$$
\frac{11+\sqrt{61}}{12}
= 1.5675208063\ldots .
$$