### PR TITLE
Improve C10c lower bound to 4/sqrt(6)

### DIFF
--- a/constants/10c.md
+++ b/constants/10c.md
@@ -2,15 +2,32 @@
 
 ## Description of constant
 
-$C_{10c}$ is the least constant $K$ for which one has
-$$\mathrm{disc}(A) \le K\sqrt{n}\qquad\text{for all }n\text{ and all }A\in[-1,1]^{n\times n}.
-$$
-where the **discrepancy** $\mathrm{disc}(A)$ is defined as
-$$\mathrm{disc}(A) \;:=\; \min_{x\in\{\pm 1\}^n}\ \|Ax\|_\infty.$$
-Equivalently, if $L_i(x_1,\dots,x_n)=\sum_{j=1}^n a_{ij}x_j$ are $n$ linear forms,
-then
-$$\mathrm{disc}((a_{ij})_{i,j=1}^n)=\min_{\varepsilon\in\{\pm 1\}^n}\max_{1\le i\le n}|L_i(\varepsilon)|.$$
+$C\_{10c}$ is the least constant $K$ for which one has
 
+$$
+\mathrm{disc}(A) \le K\sqrt{n}
+\qquad\text{for all }n\text{ and all }A\in[-1,1]^{n\times n}.
+$$
+
+Here the **discrepancy** $\mathrm{disc}(A)$ is defined as
+
+$$
+\mathrm{disc}(A) := \min_{x\in\{\pm 1\}^n} \|Ax\|_\infty.
+$$
+
+Equivalently, if the linear forms are
+
+$$
+L_i(x_1,\dots,x_n)=\sum_{j=1}^n a_{ij}x_j,
+$$
+
+then
+
+$$
+\mathrm{disc}((a_{ij})_{i,j=1}^n)=
+\min_{\varepsilon\in\{\pm 1\}^n}
+\max_{1\le i\le n}\lvert L_i(\varepsilon)\rvert.
+$$
 
 ## Known upper bounds
 
@@ -26,20 +43,123 @@ $$\mathrm{disc}((a_{ij})_{i,j=1}^n)=\min_{\varepsilon\in\{\pm 1\}^n}\max_{1\le i
 | Bound | Reference | Comments |
 | ---: | :--- | :--- |
 | $1$ | Trivial | $A=[1]$. Also achieved by Hadamard matrices [Band2024]. |
-| $\sqrt{2}\approx 1.414214$ | [Band2024] | $A = \begin{bmatrix}1&1\\1&-1\end{bmatrix}$. |
+| $\sqrt{2}\approx 1.414214$ | [Band2024] | The 2 by 2 sign matrix with rows $(1,1)$ and $(1,-1)$. |
+| $4/\sqrt{6}\approx 1.632993$ | [G2026] | A 6 by 6 sign matrix with exact discrepancy $4$. |
+
+## Certificate for the $4/\sqrt{6}$ lower bound
+
+Use the following sign matrix:
+
+```text
+ 1   1   1   1   1   1
+-1  -1  -1   1   1   1
+-1   1   1  -1   1   1
+-1   1  -1   1  -1   1
+ 1   1  -1  -1   1   1
+ 1  -1   1  -1  -1   1
+```
+
+All entries are `±1`. For a sign vector `x`, let `S` be the set of columns where the corresponding coordinate of `x` is `-1`. For row number $i$, let `T_i` be the set of columns where that row has entry `-1`:
+
+```text
+T1 = {}
+T2 = {1,2,3}
+T3 = {1,4}
+T4 = {1,3,5}
+T5 = {3,4}
+T6 = {2,4,5}
+```
+
+Then
+
+$$
+(Ax)_i = 6 - 2\lvert S\triangle T_i\rvert.
+$$
+
+Therefore the absolute value of the $i$th coordinate of `Ax` is at least $4$ whenever `S` is within Hamming distance $1$ of either `T_i` or the complement of `T_i`. The relevant centers are
+
+```text
+{}, 123, 14, 135, 34, 245, 123456, 456, 2356, 246, 1256, 136
+```
+
+where, for example, `123` denotes the set `{1,2,3}`.
+
+The sets of size 0, 1, 5, and 6 are covered by the centers `{}` and `123456`. The sets of size 2 are covered as follows:
+
+| S | center |
+| :---: | :---: |
+| 12 | 123 |
+| 13 | 123 |
+| 14 | 14 |
+| 15 | 135 |
+| 16 | 136 |
+| 23 | 123 |
+| 24 | 245 |
+| 25 | 245 |
+| 26 | 246 |
+| 34 | 34 |
+| 35 | 135 |
+| 36 | 136 |
+| 45 | 456 |
+| 46 | 456 |
+| 56 | 456 |
+
+Since the centers are closed under complementation, this also covers the sets of size 4. The sets of size 3 are covered as follows:
+
+| S | center |
+| :---: | :---: |
+| 123 | 123 |
+| 124 | 14 |
+| 125 | 1256 |
+| 126 | 1256 |
+| 134 | 14 |
+| 135 | 135 |
+| 136 | 136 |
+| 145 | 14 |
+| 146 | 14 |
+| 156 | 1256 |
+| 234 | 34 |
+| 235 | 2356 |
+| 236 | 2356 |
+| 245 | 245 |
+| 246 | 246 |
+| 256 | 1256 |
+| 345 | 34 |
+| 346 | 34 |
+| 356 | 2356 |
+| 456 | 456 |
+
+Thus every sign vector satisfies
+
+$$
+\|Ax\|_\infty \ge 4.
+$$
+
+Equality is attained. For example,
+
+```text
+x  = (1,-1,1,1,1,1)^T
+Ax = (4,2,0,-2,0,2)^T
+```
+
+Hence $\mathrm{disc}(A)=4$, and consequently
+
+$$
+C_{10c}\ge \frac{4}{\sqrt{6}}\approx 1.632993.
+$$
 
 ## Further remarks
 
 - For large $n$, the best asymptotic lower bound remains $1$ [Band2024].
-- Replacing the entrywise bound $|a_{ij}|\le 1$ by an $\ell_2$-bound on columns
-  leads to the Komlós conjecture, which would imply (after scaling) Spencer-type discrepancy bounds.
+- Replacing the entrywise bound by an $\ell\_2$-bound on columns leads to the Komlós conjecture, which would imply, after scaling, Spencer-type discrepancy bounds.
 
 ## References
 
 - [AS2008] Alon, N.; Spencer, J. *The Probabilistic Method*, 3rd ed. Wiley, 2008. (See the discussion around “Six Standard Deviations Suffice”.)
-- [Band2024] Bandeira, A. S. [*Did just a couple of deviations suffice all along?](https://randomstrasse101.math.ethz.ch/posts/HowManyDeviations/) (problems 10–14).* Randomstrasse 101 blog post (Dec 19, 2024).
+- [Band2024] Bandeira, A. S. [*Did just a couple of deviations suffice all along?*](https://randomstrasse101.math.ethz.ch/posts/HowManyDeviations/) (problems 10–14). Randomstrasse 101 blog post (Dec 19, 2024).
 - [Ban2010] Bansal, N. *Constructive algorithms for discrepancy minimization.* FOCS 2010, 3–10.
 - [Bel2013] Belshaw, A. W. *Strong Normality, Modular Normality, and Flat Polynomials: Applications of Probability in Number Theory and Analysis.* PhD thesis, Simon Fraser University, 2013.
+- [G2026] Griego, Sebastian. 6 by 6 sign-matrix certificate for C10c, submitted to this repository (2026).
 - [LM2015] Lovett, S.; Meka, R. *Constructive discrepancy minimization by walking on the edges.* SIAM J. Comput. **44** (5) (2015), 1573–1582. [arXiv:1203.5747](https://arxiv.org/abs/1203.5747)
 - [MO175826] MathOverflow. [*Spencer’s “six standard deviations” theorem – better constants?*](https://mathoverflow.net/questions/175826/) Question 175826 (2014).
 - [PV2022] Pesenti, L.; Vladu, A. *Discrepancy Minimization via Regularization.* [arXiv:2211.05509](https://arxiv.org/abs/2211.05509)


### PR DESCRIPTION
## Summary

This updates `constants/10c.md` with a finite-dimensional certificate giving

```text
C_{10c} >= 4/sqrt(6) ≈ 1.632993.
```

The certificate uses a 6 by 6 sign matrix `A` with

```text
disc(A) = min_{x in {±1}^6} ||Ax||_∞ = 4.
```

This improves the previously displayed lower bound of `sqrt(2)`.

## Certificate

The added certificate gives the explicit matrix

```text
 1   1   1   1   1   1
-1  -1  -1   1   1   1
-1   1   1  -1   1   1
-1   1  -1   1  -1   1
 1   1  -1  -1   1   1
 1  -1   1  -1  -1   1
```

The page includes a finite Hamming-covering verification showing that every sign vector satisfies

```text
||Ax||_∞ >= 4.
```

Equality is attained, for example at

```text
x = (1,-1,1,1,1,1)^T,
```

where

```text
Ax = (4,2,0,-2,0,2)^T.
```

Therefore `disc(A) = 4`, giving the claimed lower bound.

## Verification

The certificate was checked by exhaustive enumeration of all `2^6 = 64` sign vectors. The computation confirms that the minimum value of `||Ax||_∞` is exactly `4`.

## Changed file

- `constants/10c.md`

## AI assistance disclosure

The construction, patch, PR text, and verification script were prepared with assistance from ChatGPT 5.5 Pro. The submitter rechecked the construction and arithmetic before submission.
