### PR TITLE
Improve C_59 upper bound

### DIFF
--- a/constants/59a.md
+++ b/constants/59a.md
@@ -43,10 +43,10 @@ The exact value of $K_d$ is unknown for every $d>1$; in particular, the exact va
 The best established range currently is
 
 $$
-0.3006\ \le\ K_2\ <\ 0.3177.
+0.3006\ \le\ K_2\ <\ 0.3174541.
 $$
 
-<a href="#Kne2025-lb-K2-0-3006">[Kne2025-lb-K2-0-3006]</a> <a href="#BPWW2026-ub-K2-0-3177">[BPWW2026-ub-K2-0-3177]</a>
+<a href="#Kne2025-lb-K2-0-3006">[Kne2025-lb-K2-0-3006]</a> <a href="#G2026-ub-K2-0-3174541">[G2026-ub-K2-0-3174541]</a>
 
 ## Known upper bounds
 
@@ -54,6 +54,7 @@ $$
 | ----- | --------- | -------- |
 | $1/3$ | <a href="#BK1997">[BK1997]</a> | General upper bound $K_n\le 1/3$ (hence $K_2\le 1/3$). <a href="#BK1997-ub-1-3">[BK1997-ub-1-3]</a> |
 | $0.3177$ | <a href="#BPWW2026">[BPWW2026]</a> | Explicit construction giving $K_2<0.3177$ (Theorem 6.4). <a href="#BPWW2026-ub-K2-0-3177">[BPWW2026-ub-K2-0-3177]</a> |
+| $0.3174541$ | <a href="#G2026">[G2026]</a> | Degree-$(250,250)$ polynomial from a rational-inner Fejer averaging certificate. Exact integer verification gives $B\_{3174541/10000000}(p)>1$. <a href="#G2026-ub-K2-0-3174541">[G2026-ub-K2-0-3174541]</a> |
 
 ## Known lower bounds
 
@@ -118,6 +119,11 @@ $$
 	  **loc:** arXiv v1 PDF p.18, Theorem 6.4
 	  **quote:** “Theorem 6.4. $K_2<0.3177$.”
 
+- <a id="G2026"></a>**[G2026]** Griego, Sebastian. Rational-inner Fejer averaging certificate for the bidisc Bohr radius bound $K\_2<0.3174541$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/75) (2026).
+	- <a id="G2026-ub-K2-0-3174541"></a>**[G2026-ub-K2-0-3174541]**
+	  **loc:** pull request certificate and exact verifier
+	  **quote:** “The exact integer verifier proves $B\_{3174541/10000000}(p)>1+1/7307638490$ and the rational-inner Fejer averaging certificate proves $\lvert p\rvert\le 1$ on the bidisc.”
+
 ## Contribution notes
 
-Prepared with assistance from ChatGPT 5.2 Pro.
+Prepared initially with assistance from ChatGPT 5.2 Pro and updated with assistance from ChatGPT 5.5 Pro.


### PR DESCRIPTION
## Summary

This updates the upper bound for the Bohr radius of the bidisc from

$$
K_2 < 0.3177
$$

to

$$
K_2 < 0.3174541.
$$

The bound comes from a degree-$(250,250)$ polynomial obtained as a double Fejer mean of the rational-inner function

$$
F(z,w)=\frac{981359-660190z-641550w+1000000zw}
{1000000-641550z-660190w+981359zw}.
$$

At

$$
r=\frac{3174541}{10000000},
$$

the exact verifier below proves

$$
B_r(p)>1+\frac1{7307638490}>1.
$$

Since $B_s(p)$ is continuous in $s$, the Bohr inequality fails at some $s<r$, and hence $K_2<r$.

## Certificate

Let

$$
L=1000000,
\quad A=641550,
\quad C=660190,
\quad D=981359,
\quad N=250,
\quad M=251.
$$

Define

$$
Q(z,w)=L-Az-Cw+Dzw,
\qquad
G(z,w)=D-Cz-Aw+Lzw.
$$

For $\lvert w\rvert=1$,

$$
|L-Cw|^2-|Dw-A|^2
=L^2+C^2-D^2-A^2-2(LC-AD)\operatorname{Re}w.
$$

Here

$$
LC-AD=30599133550>0,
$$

so the minimum on $\lvert w\rvert=1$ occurs at $w=1$. The exact integer check is

$$
(L-C)^2-(D-A)^2=679619>0.
$$

Thus $\lvert Dw-A\rvert<\lvert L-Cw\rvert$ on $\lvert w\rvert=1$. Since $(Dw-A)/(L-Cw)$ is analytic on $\lvert w\rvert\le 1$, the same strict inequality holds on $\lvert w\rvert\le 1$. Hence $Q$ has no zero on the closed bidisc. On the torus,

$$
G(z,w)=zw\overline{Q(z,w)}.
$$

Therefore $F=G/Q$ is analytic on the closed bidisc and satisfies $\lvert F\rvert=1$ on the torus, hence $\lvert F\rvert\le 1$ on the bidisc.

Write

$$
F(z,w)=\sum_{j,k\ge0}a_{j,k}z^jw^k.
$$

The coefficient integers $\nu_{j,k}$ are defined by

$$
a_{j,k}=\frac{\nu_{j,k}}{L^{j+k+1}}
$$

and the recurrence

$$
\nu_{j,k}=A\nu_{j-1,k}+C\nu_{j,k-1}-DL\nu_{j-1,k-1}+e_{j,k}L^{j+k},
$$

with missing-index terms taken to be zero, where

$$
e_{0,0}=D,
\quad e_{1,0}=-C,
\quad e_{0,1}=-A,
\quad e_{1,1}=L,
$$

and all other $e_{j,k}$ are zero.

Define the polynomial

$$
p(z,w)=\sum_{0\le j,k\le N}c_{j,k}z^jw^k
$$

by

$$
c_{j,k}=\frac{(M-j)(M-k)\nu_{j,k}}{M^2L^{j+k+1}}.
$$

This is the double Fejer mean of $F$. Since the Fejer kernel is a nonnegative probability kernel, $p$ is a convex average of boundary values of $F$ on the torus. Hence $\lvert p\rvert\le 1$ on the torus, and by the maximum principle $\lvert p\rvert\le 1$ on the bidisc.

## Verification

The following script uses integer arithmetic for every assertion. Decimal arithmetic is used only for human-readable output. It also has an optional `--write-coefficients` flag that writes the full rational coefficient list for $p$.

```python
#!/usr/bin/env python3
"""
Exact certificate for the upper bound K_2 < 3174541/10000000.

All assertions use integer arithmetic only. Decimal arithmetic is used only for
human-readable output.
"""

from __future__ import annotations

import argparse
from decimal import Decimal, getcontext
from math import gcd

L = 10**6
A = 641550
C = 660190
D = 981359
R = 3174541
T = 10**7
N = 250
M = N + 1
MARGIN_DEN = 7307638490


def compute_nu() -> list[list[int]]:
    """Return nu[j][k] where a[j][k] = nu[j][k] / L**(j+k+1)."""
    nu = [[0] * (N + 1) for _ in range(N + 1)]
    for j in range(N + 1):
        for k in range(N + 1):
            v = 0
            if j > 0:
                v += A * nu[j - 1][k]
            if k > 0:
                v += C * nu[j][k - 1]
            if j > 0 and k > 0:
                v -= D * L * nu[j - 1][k - 1]
            if j == 0 and k == 0:
                v += D
            elif j == 1 and k == 0:
                v -= C * L
            elif j == 0 and k == 1:
                v -= A * L
            elif j == 1 and k == 1:
                v += L**3
            nu[j][k] = v
    return nu


def coefficient_fraction(nu: list[list[int]], j: int, k: int) -> tuple[int, int]:
    """Return the exact rational coefficient c[j][k] as numerator, denominator."""
    numerator = (M - j) * (M - k) * nu[j][k]
    denominator = M * M * L ** (j + k + 1)
    g = gcd(abs(numerator), denominator)
    return numerator // g, denominator // g


def compute_br_fraction(nu: list[list[int]]) -> tuple[int, int]:
    """Return the exact fraction B_{R/T}(p)."""
    Lpow = [1] * (2 * N + 2)
    Tpow = [1] * (2 * N + 1)
    Rpow = [1] * (2 * N + 1)
    for i in range(1, 2 * N + 2):
        Lpow[i] = Lpow[i - 1] * L
    for i in range(1, 2 * N + 1):
        Tpow[i] = Tpow[i - 1] * T
        Rpow[i] = Rpow[i - 1] * R

    numerator = 0
    for j in range(N + 1):
        for k in range(N + 1):
            n = j + k
            numerator += (
                abs(nu[j][k])
                * Rpow[n]
                * (M - j)
                * (M - k)
                * Lpow[2 * N - n]
                * Tpow[2 * N - n]
            )

    denominator = Lpow[2 * N + 1] * Tpow[2 * N] * M * M
    return numerator, denominator


def write_coefficients(nu: list[list[int]], filename: str) -> None:
    with open(filename, "w", encoding="utf-8") as out:
        out.write("j\tk\tnumerator\tdenominator\n")
        for j in range(N + 1):
            for k in range(N + 1):
                num, den = coefficient_fraction(nu, j, k)
                out.write(f"{j}\t{k}\t{num}\t{den}\n")


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--write-coefficients",
        metavar="PATH",
        help="write the complete coefficient list for p as a TSV file",
    )
    args = parser.parse_args()

    # Radius check: R/T < 3177/10000.
    assert R > 0
    assert R * 10000 < 3177 * T

    # Stability of Q(z,w)=L-Az-Cw+Dzw on the closed bidisc.
    # For |w|=1, |L-Cw|^2-|Dw-A|^2 is minimized at w=1 because LC-AD>0.
    assert C < L
    assert L * C - A * D > 0
    assert (L - C) ** 2 - (D - A) ** 2 > 0

    nu = compute_nu()
    numerator, denominator = compute_br_fraction(nu)

    assert numerator > denominator
    assert MARGIN_DEN * numerator > (MARGIN_DEN + 1) * denominator

    if args.write_coefficients:
        write_coefficients(nu, args.write_coefficients)

    getcontext().prec = 80
    value = Decimal(numerator) / Decimal(denominator)
    excess = Decimal(numerator - denominator) / Decimal(denominator)

    print(f"r = {R}/{T}")
    print(f"bidegree = ({N}, {N})")
    print("proved: R/T < 3177/10000")
    print("proved: denominator L-Az-Cw+Dzw is stable on the closed bidisc")
    print("proved: |p| <= 1 on the bidisc by rational-inner Fejer averaging")
    print(f"proved: B_r(p) > 1 + 1/{MARGIN_DEN}")
    print(f"B_r(p) = {value}")
    print(f"B_r(p)-1 = {excess}")


if __name__ == "__main__":
    main()

```

Expected output includes:

```text
r = 3174541/10000000
bidegree = (250, 250)
proved: R/T < 3177/10000
proved: denominator L-Az-Cw+Dzw is stable on the closed bidisc
proved: |p| <= 1 on the bidisc by rational-inner Fejer averaging
proved: B_r(p) > 1 + 1/7307638490
B_r(p) = 1.0000000001368431130617046818753061666655003380903583500779450859192096580842119
B_r(p)-1 = 1.3684311306170468187530616666550033809035835007794508591920965808421187976372851E-10
```

Therefore

$$
B_{3174541/10000000}(p)>1,
$$

with $\lvert p\rvert\le 1$ on the bidisc, so

$$
K_2<0.3174541.
$$

## AI assistance disclosure

The construction, patch, PR text, and verification script were prepared with assistance from ChatGPT 5.5 Pro. The submitter rechecked the construction and arithmetic before submission.
