### PR TITLE
Improve upper bound for Davenport constant C_{53} to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [50](https://teorth.github.io/optimizationproblems/constants/50a.html) | Approximation ratio for quantum Max Cut | 0.611 | $<1$ (0.5 for product states) |
 | [51](https://teorth.github.io/optimizationproblems/constants/51a.html) | Erdős maximum term problem | 0.5850788 | $\frac{2}{\pi}\approx 0.63662$ |
 | [52](https://teorth.github.io/optimizationproblems/constants/52a.html) | Satisfiability threshold for random 3-SAT | 3.52 | 4.490 |
-| [53](https://teorth.github.io/optimizationproblems/constants/53a.html) | Davenport constant for $C_n^3$ | 3 | 20369 |
+| [53](https://teorth.github.io/optimizationproblems/constants/53a.html) | Davenport constant for $C_n^3$ | 3 | 4 |
 | [54](https://teorth.github.io/optimizationproblems/constants/54a.html) | Beurling–Ahlfors transform constant | 1 | 1.575 |
 | [55](https://teorth.github.io/optimizationproblems/constants/55a.html) | Coefficient of the acyclic chromatic index | 1 | 3.142 |
 | [56](https://teorth.github.io/optimizationproblems/constants/56a.html) | $\mathrm{GL}_2$ Ramanujan conjecture exponent | 0 | $\tfrac{7}{64}=0.109375$ |

--- a/constants/53a.md
+++ b/constants/53a.md
@@ -86,7 +86,7 @@ Published work before the 2019 preprint includes Gao (2000) on rank-$3$ groups a
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $4$ | <a href="#G2026">[G2026]</a> | Uses the local estimate $D_k(C_p^3)\le pk+p^2$ from <a href="#BSP2012">[BSP2012]</a> and <a href="#FS2010">[FS2010]</a>, then starts the induction at $Q=P(n)$. This gives $D(C_n^3)\le 4n-P(n)-2$, hence $C_{53}\le 4$. |
+| $4$ | <a href="#Grinsztajn2026">[Grinsztajn2026]</a> | From the pointwise estimate $D(C_n^3)\le 4n-P(n)-2$, where $P(n)=\max_{p^a\parallel n}p^a$. Since $P(n)\ge2$, this gives $C_{53}\le4$. |
 | $20369$ | <a href="#Zak2019">[Zak2019]</a> | From Corollary 3.11: $D(C_n^3)\le 20369(n-1)+1$ for all $n\ge 2$, hence $C_{53}\le 20369$. <a href="#Zak2019-cor3.11">[Zak2019-cor3.11]</a> |
 
 ## Known lower bounds
@@ -151,12 +151,8 @@ Published work before the 2019 preprint includes Gao (2000) on rank-$3$ groups a
 
 - <a id="Gao2000"></a>**[Gao2000]** Gao, W. D. *On Davenport's constant of finite abelian groups with rank three.* Discrete Mathematics **222** (2000), no. 1--3, 111–124. DOI: https://doi.org/10.1016/S0012-365X(00)00010-8. [Google Scholar](https://scholar.google.com/scholar?q=On+Davenport%27s+constant+of+finite+abelian+groups+with+rank+three)
 
-- <a id="G2026"></a>**[G2026]** Grinsztajn, Max. Inductive proof of the bound $D(C_n^3)\le 4n-P(n)-2$, submitted to this repository (2026).
-
-- <a id="BSP2012"></a>**[BSP2012]** Bhowmik, Gautami; Schlage-Puchta, Jan-Christoph. *Davenport's constant for groups with large exponent.* Contemporary Mathematics **579** (2012), 21--32. arXiv: https://arxiv.org/abs/1702.03403. DOI: https://doi.org/10.48550/arXiv.1702.03403. [Google Scholar](https://scholar.google.com/scholar?q=Bhowmik+Schlage-Puchta+Davenport%27s+constant+for+groups+with+large+exponent)
-
-- <a id="FS2010"></a>**[FS2010]** Freeze, Michael; Schmid, Wolfgang A. *Remarks on a generalization of the Davenport constant.* Discrete Mathematics **310** (2010), 3373--3389. DOI: https://doi.org/10.1016/j.disc.2010.07.028. arXiv: https://arxiv.org/abs/0905.4248. [Google Scholar](https://scholar.google.com/scholar?q=Freeze+Schmid+Remarks+on+a+generalization+of+the+Davenport+constant)
+- <a id="Grinsztajn2026"></a>**[Grinsztajn2026]** Grinsztajn, Max. *An upper bound for the Davenport constant of $C_n^3$.* Proof PDF: https://github.com/maaxgrin/davenport-cn3-bound/blob/main/davenport_cn3_bound.pdf
 
 ## Contribution notes
 
-The proof of the new upper bound was found by GPT-5.5 Pro; citations and mathematical details were reviewed by the human contributor.
+Prepared with assistance from GPT-5.5 Pro.

--- a/constants/53a.md
+++ b/constants/53a.md
@@ -21,26 +21,48 @@ $$
 
 the maximal normalized Davenport constant among the rank-$3$ groups $C_n^3$.
 
-The best general bounds currently available in this setting include the explicit uniform inequality
+The following explicit uniform inequality is obtained from the inductive method
+and known multi-wise Davenport estimates over elementary prime groups:
 
 $$
-3(n-1)+1\ \le\ D(C_n^3)\ \le\ \min\{20369,\ 3^{\omega(n)}\}(n-1)+1
+3(n-1)+1\ \le\ D(C_n^3)\ \le\ 4n-P(n)-2
 \qquad (n\ge 2),
+$$
+
+where
+
+$$
+P(n)=\max_{p^a\parallel n}p^a
+$$
+
+is the largest primary component of $n$. Since $P(n)\ge 2$, this gives
+
+$$
+D(C_n^3)\le 4n-4=4(n-1),
+$$
+
+and hence
+
+$$
+C_{53}\le 4.
+$$
+
+The previously recorded published bounds included
+
+$$
+3(n-1)+1\ \le\ D(C_n^3)\ \le\ \min\{20369,\ 3^{\omega(n)}\}(n-1)+1,
 $$
 
 where $\omega(n)$ is the number of distinct prime factors of $n$.
 <a href="#Zak2019-omega-def">[Zak2019-omega-def]</a> <a href="#Zak2019-cor3.11">[Zak2019-cor3.11]</a>
-
-Here, the $3^{\omega(n)}$ term is inherited from earlier published work, while the uniform numeric constant $20369$ is the new explicit contribution in <a href="#Zak2019">[Zak2019]</a>.
+Here, the $3^{\omega(n)}$ term is inherited from earlier published work, while the uniform numeric constant $20369$ is the explicit contribution in <a href="#Zak2019">[Zak2019]</a>.
 <a href="#Zak2019-prev-3omega">[Zak2019-prev-3omega]</a> <a href="#CMMPT2012">[CMMPT2012]</a>
 
 In particular,
 
 $$
-3\ \le\ C_{53}\ \le\ 20369.
+3\ \le\ C_{53}\ \le\ 4.
 $$
-
-<a href="#Zak2019-cor3.11">[Zak2019-cor3.11]</a>
 
 A long-standing conjecture (in a stronger, pointwise form) predicts that for all $n\ge 2$ one has
 
@@ -64,6 +86,7 @@ Published work before the 2019 preprint includes Gao (2000) on rank-$3$ groups a
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
+| $4$ | <a href="#G2026">[G2026]</a> | Uses the local estimate $D_k(C_p^3)\le pk+p^2$ from <a href="#BSP2012">[BSP2012]</a> and <a href="#FS2010">[FS2010]</a>, then starts the induction at $Q=P(n)$. This gives $D(C_n^3)\le 4n-P(n)-2$, hence $C_{53}\le 4$. |
 | $20369$ | <a href="#Zak2019">[Zak2019]</a> | From Corollary 3.11: $D(C_n^3)\le 20369(n-1)+1$ for all $n\ge 2$, hence $C_{53}\le 20369$. <a href="#Zak2019-cor3.11">[Zak2019-cor3.11]</a> |
 
 ## Known lower bounds
@@ -128,6 +151,12 @@ Published work before the 2019 preprint includes Gao (2000) on rank-$3$ groups a
 
 - <a id="Gao2000"></a>**[Gao2000]** Gao, W. D. *On Davenport's constant of finite abelian groups with rank three.* Discrete Mathematics **222** (2000), no. 1--3, 111–124. DOI: https://doi.org/10.1016/S0012-365X(00)00010-8. [Google Scholar](https://scholar.google.com/scholar?q=On+Davenport%27s+constant+of+finite+abelian+groups+with+rank+three)
 
+- <a id="G2026"></a>**[G2026]** Grinsztajn, Max. Inductive proof of the bound $D(C_n^3)\le 4n-P(n)-2$, submitted to this repository (2026).
+
+- <a id="BSP2012"></a>**[BSP2012]** Bhowmik, Gautami; Schlage-Puchta, Jan-Christoph. *Davenport's constant for groups with large exponent.* Contemporary Mathematics **579** (2012), 21--32. arXiv: https://arxiv.org/abs/1702.03403. DOI: https://doi.org/10.48550/arXiv.1702.03403. [Google Scholar](https://scholar.google.com/scholar?q=Bhowmik+Schlage-Puchta+Davenport%27s+constant+for+groups+with+large+exponent)
+
+- <a id="FS2010"></a>**[FS2010]** Freeze, Michael; Schmid, Wolfgang A. *Remarks on a generalization of the Davenport constant.* Discrete Mathematics **310** (2010), 3373--3389. DOI: https://doi.org/10.1016/j.disc.2010.07.028. arXiv: https://arxiv.org/abs/0905.4248. [Google Scholar](https://scholar.google.com/scholar?q=Freeze+Schmid+Remarks+on+a+generalization+of+the+Davenport+constant)
+
 ## Contribution notes
 
-Prepared with assistance from ChatGPT 5.2 Pro.
+The proof of the new upper bound was found by GPT-5.5 Pro; citations and mathematical details were reviewed by the human contributor.


### PR DESCRIPTION
This PR updates the entry for the Davenport constant of $C_n^3$, improving the recorded upper bound

$$
C_{53}\le 20369
$$

to

$$
C_{53}\le 4.
$$

The update records the stronger pointwise estimate

$$
D(C_n^3)\le 4n-P(n)-2,
\qquad
P(n)=\max_{p^a\parallel n}p^a.
$$

Since $P(n)\ge 2$, this gives

$$
D(C_n^3)\le 4(n-1)
$$

for every $n\ge 2$, and hence $C_{53}\le 4$.

The proof was discovered with assistance from GPT-5.5 Pro. The deduction from the cited zero-sum inputs was also checked in a conditional Lean 4 formalization prepared with assistance from Aristotle and GPT-5.5 Pro.

The proof PDF, references, and conditional Lean 4 formalization are available in this auxiliary repository:

https://github.com/maaxgrin/davenport-cn3-bound