### PR TITLE
Update C71 lower bound using Hod 2017

### DIFF
--- a/constants/71a.md
+++ b/constants/71a.md
@@ -37,18 +37,18 @@ $$
 The conjecture is equivalent to $C_{71}<\infty$, and this remains open.
 <a href="#ODWZ2011-open-problem">[ODWZ2011-open-problem]</a>
 
-An explicit construction gives
+An explicit asymptotic construction gives
 
 $$
-C_{71}\ \ge\ 6.278.
+C_{71}\ >\ 6.4547837.
 $$
 
-<a href="#OT2013-lb-6-278">[OT2013-lb-6-278]</a>
+<a href="#Hod2017-thm4.4">[Hod2017-thm4.4]</a>
 
 Hence the best established range is
 
 $$
-6.278\ \le\ C_{71}\ \le\ \infty.
+6.4547837\ <\ C_{71}\ \le\ \infty.
 $$
 
 ## Known upper bounds
@@ -63,6 +63,7 @@ $$
 | ----- | --------- | -------- |
 | $0$ |  | Trivial bound from nonnegativity. |
 | $6.278$ | [[OT2013](#OT2013)] | Explicit example with ratio at least $6.278$. <a href="#OT2013-lb-6-278">[OT2013-lb-6-278]</a> |
+| $>6.4547837$ | [[Hod2017](#Hod2017)] | Theorem 4.4 gives $C\ge \beta(1/2)>6.4547837$, even when restricted to monotone functions. <a href="#Hod2017-thm4.4">[Hod2017-thm4.4]</a> |
 
 ## Additional comments and links
 
@@ -87,6 +88,12 @@ $$
 	  **loc:** arXiv PDF p.1, Abstract
 	  **quote:** "Our techniques also yield an explicit function with the largest known ratio of $C \ge 6.278$ between $H[f]$ and $\mathrm{Inf}[f]$, improving on the previous lower bound of $4.615$."
 
+- <a id="Hod2017"></a>**[Hod2017]** Hod, Rani. *Improved Lower Bounds for the Fourier Entropy/Influence Conjecture via Lexicographic Functions.* arXiv:1711.00762, 2017. [arXiv](https://arxiv.org/abs/1711.00762). [PDF](https://arxiv.org/pdf/1711.00762).
+	- <a id="Hod2017-thm4.4"></a>**[Hod2017-thm4.4]**
+	  **loc:** arXiv PDF p. 15, Theorem 4.4
+	  **quote:** "Any constant $C$ in Conjecture 1.1 satisfies $C\ge \beta(1/2)>6.4547837$, even when restricted to monotone functions."
+
 ## Contribution notes
 
 Prepared with assistance from ChatGPT 5.2 Pro.
+This update was prepared with assistance from Codex. Citations and mathematical details were reviewed by the human contributor.


### PR DESCRIPTION
Updates the lower bound for C71 using Theorem 4.4 of Rani Hod, *Improved Lower Bounds for the Fourier Entropy/Influence Conjecture via Lexicographic Functions*.

Paper: https://arxiv.org/abs/1711.00762

The current page records the O'Donnell-Tan lower bound

$$
C_{71}\ge 6.278.
$$

Hod's Theorem 4.4 gives

$$
C_{71}\ge \beta(1/2)>6.4547837,
$$

even when restricted to monotone functions.

This improves the currently listed lower bound.
