### PR TITLE
Improve upper bound for Borsuk failure dimension C28 to 63

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [26b](https://teorth.github.io/optimizationproblems/constants/26b.html) |Multilinear Bohnenblust--Hille constant (real) | $2$ | $\infty$ |
 | [27a](https://teorth.github.io/optimizationproblems/constants/27a.html) | Chromatic number of the plane | 5 | 7 |
 | [27b](https://teorth.github.io/optimizationproblems/constants/27b.html) | Maximum Chromatic Number of Biplanar Graphs | 9 | 12 |
-| [28](https://teorth.github.io/optimizationproblems/constants/28a.html) | Smallest dimension in which Borsuk’s conjecture fails | 4 | 64 |
+| [28](https://teorth.github.io/optimizationproblems/constants/28a.html) | Smallest dimension in which Borsuk’s conjecture fails | 4 | 63 |
 | [29](https://teorth.github.io/optimizationproblems/constants/29a.html) | Kissing number in dimension $5$ | 40 | 44 |
 | [30](https://teorth.github.io/optimizationproblems/constants/30a.html) | Stanley–Wilf limit for the permutation pattern $1324$ | 10.27 | 13.5 |
 | [31](https://teorth.github.io/optimizationproblems/constants/31a.html) | Chvátal–Sankoff constant for a binary alphabet | 0.792665992 (0.79970*) | 0.826280 |

--- a/appendices/28_borsuk63_verification.py
+++ b/appendices/28_borsuk63_verification.py
@@ -1,0 +1,284 @@
+from itertools import combinations, product
+from collections import deque
+
+
+"""Exact finite verification for the 63-dimensional Borsuk construction.
+
+The script reconstructs the G_2(4) strongly regular graph from PG(2,16),
+checks the partition B_1, B_2, B_3, C used in the proof, and verifies the
+clique obstructions that force every smaller-diameter part to have size at most
+5. It uses only integer arithmetic and bitsets.
+"""
+
+
+MOD_POLY = 0b10011  # x^4 + x + 1, without the x^4 term for reduction below.
+
+
+def gf_mul(a, b):
+    out = 0
+    aa = a
+    bb = b
+    while bb:
+        if bb & 1:
+            out ^= aa
+        bb >>= 1
+        aa <<= 1
+        if aa & 0b10000:
+            aa ^= MOD_POLY
+    return out & 0b1111
+
+
+def gf_pow(a, e):
+    out = 1
+    while e:
+        if e & 1:
+            out = gf_mul(out, a)
+        a = gf_mul(a, a)
+        e >>= 1
+    return out
+
+
+INV = [0] * 16
+for a in range(1, 16):
+    INV[a] = gf_pow(a, 14)
+    assert gf_mul(a, INV[a]) == 1
+
+
+def gf_div(a, b):
+    return gf_mul(a, INV[b])
+
+
+def normalize(v):
+    for x in v:
+        if x:
+            inv = INV[x]
+            return tuple(gf_mul(inv, y) for y in v)
+    raise ValueError("zero vector")
+
+
+def add(u, v):
+    return tuple(x ^ y for x, y in zip(u, v))
+
+
+def smul(a, v):
+    return tuple(gf_mul(a, x) for x in v)
+
+
+def hermitian(u, w):
+    return gf_mul(u[0], gf_pow(w[0], 4)) ^ gf_mul(u[1], gf_pow(w[1], 4)) ^ gf_mul(u[2], gf_pow(w[2], 4))
+
+
+def line_points(a, b):
+    pts = set()
+    for lam, mu in product(range(16), repeat=2):
+        if lam == 0 and mu == 0:
+            continue
+        pts.add(normalize(add(smul(lam, a), smul(mu, b))))
+    return pts
+
+
+def bit_count(x):
+    return x.bit_count()
+
+
+def has_clique(adj, vertices, size):
+    verts = list(vertices)
+    allowed = 0
+    for v in verts:
+        allowed |= 1 << v
+
+    def expand(cands, depth):
+        if depth == size:
+            return True
+        if bit_count(cands) < size - depth:
+            return False
+        while cands:
+            lsb = cands & -cands
+            v = lsb.bit_length() - 1
+            cands ^= lsb
+            if expand(cands & adj[v], depth + 1):
+                return True
+        return False
+
+    return expand(allowed, 0)
+
+
+def clique_witness(adj, vertices, size):
+    allowed = 0
+    for v in vertices:
+        allowed |= 1 << v
+
+    def expand(cands, chosen):
+        if len(chosen) == size:
+            return chosen
+        if bit_count(cands) < size - len(chosen):
+            return None
+        while cands:
+            lsb = cands & -cands
+            v = lsb.bit_length() - 1
+            cands ^= lsb
+            out = expand(cands & adj[v], chosen + [v])
+            if out is not None:
+                return out
+        return None
+
+    return expand(allowed, [])
+
+
+def main():
+    assert all(gf_mul(a, b) == gf_mul(b, a) for a in range(16) for b in range(16))
+
+    points = []
+    seen = set()
+    for v in product(range(16), repeat=3):
+        if v == (0, 0, 0):
+            continue
+        p = normalize(v)
+        if p not in seen:
+            seen.add(p)
+            points.append(p)
+    points.sort()
+    print("projective points", len(points))
+    assert len(points) == 273
+
+    isotropic = [p for p in points if hermitian(p, p) == 0]
+    nonisotropic = [p for p in points if hermitian(p, p) != 0]
+    print("isotropic", len(isotropic), "nonisotropic", len(nonisotropic))
+    assert len(isotropic) == 65
+    assert len(nonisotropic) == 208
+
+    iso_index = {p: i for i, p in enumerate(isotropic)}
+    noniso_index = {p: i for i, p in enumerate(nonisotropic)}
+
+    orth = [[False] * len(nonisotropic) for _ in nonisotropic]
+    for i, a in enumerate(nonisotropic):
+        for j in range(i + 1, len(nonisotropic)):
+            if hermitian(a, nonisotropic[j]) == 0:
+                orth[i][j] = orth[j][i] = True
+
+    vertices = []
+    for i, j, k in combinations(range(len(nonisotropic)), 3):
+        if orth[i][j] and orth[i][k] and orth[j][k]:
+            vertices.append((i, j, k))
+    print("vertices", len(vertices))
+    assert len(vertices) == 416
+
+    triangles = []
+    for tri in vertices:
+        pts = set()
+        for i, j in combinations(tri, 2):
+            pts |= {p for p in line_points(nonisotropic[i], nonisotropic[j]) if p in iso_index}
+        assert len(pts) == 15
+        mask = 0
+        for p in pts:
+            mask |= 1 << iso_index[p]
+        triangles.append(mask)
+
+    n = len(vertices)
+    adj = [0] * n
+    edge_count = 0
+    for i in range(n):
+        ti = triangles[i]
+        for j in range(i + 1, n):
+            if bit_count(ti & triangles[j]) == 3:
+                adj[i] |= 1 << j
+                adj[j] |= 1 << i
+                edge_count += 1
+    degrees = sorted(set(bit_count(a) for a in adj))
+    print("degrees", degrees, "edges", edge_count)
+    assert degrees == [100]
+    assert edge_count == 20800
+
+    lambdas = set()
+    mus = set()
+    for i in range(n):
+        ai = adj[i]
+        for j in range(i + 1, n):
+            common = bit_count(ai & adj[j])
+            if (ai >> j) & 1:
+                lambdas.add(common)
+            else:
+                mus.add(common)
+    print("lambda", sorted(lambdas), "mu", sorted(mus))
+    assert lambdas == {36}
+    assert mus == {20}
+
+    q0 = isotropic[0]
+    B = []
+    for idx, tri in enumerate(vertices):
+        if any(hermitian(nonisotropic[i], q0) == 0 for i in tri):
+            B.append(idx)
+    Bset = set(B)
+    C = [i for i in range(n) if i not in Bset]
+    print("B size", len(B), "C size", len(C))
+    assert len(B) == 96
+    assert len(C) == 320
+
+    Bmask = sum(1 << i for i in B)
+    seen_b = set()
+    comps = []
+    for start in B:
+        if start in seen_b:
+            continue
+        q = deque([start])
+        seen_b.add(start)
+        comp = []
+        while q:
+            v = q.popleft()
+            comp.append(v)
+            nb = adj[v] & Bmask
+            while nb:
+                lsb = nb & -nb
+                w = lsb.bit_length() - 1
+                nb ^= lsb
+                if w not in seen_b:
+                    seen_b.add(w)
+                    q.append(w)
+        comps.append(sorted(comp))
+    comps.sort(key=lambda x: (len(x), x[0]))
+    print("B component sizes", [len(c) for c in comps])
+    assert [len(c) for c in comps] == [32, 32, 32]
+    B1, B2, B3 = comps
+    masks = [sum(1 << i for i in comp) for comp in comps]
+    Cmask = sum(1 << i for i in C)
+    for a, comp in enumerate(comps):
+        internal = sorted(set(bit_count(adj[v] & masks[a]) for v in comp))
+        print(f"B{a+1} internal", internal)
+        assert internal == [20]
+        for b, mask in enumerate(masks):
+            if a != b:
+                cross = sorted(set(bit_count(adj[v] & mask) for v in comp))
+                print(f"B{a+1} to B{b+1}", cross)
+                assert cross == [0]
+        to_c = sorted(set(bit_count(adj[v] & Cmask) for v in comp))
+        print(f"B{a+1} to C", to_c)
+        assert to_c == [80]
+    for a, mask in enumerate(masks):
+        c_to_b = sorted(set(bit_count(adj[v] & mask) for v in C))
+        print(f"C to B{a+1}", c_to_b)
+        assert c_to_b == [8]
+    c_internal = sorted(set(bit_count(adj[v] & Cmask) for v in C))
+    print("C internal", c_internal)
+    assert c_internal == [76]
+
+    all_vertices = list(range(n))
+    k5 = clique_witness(adj, all_vertices, 5)
+    has_k6 = has_clique(adj, all_vertices, 6)
+    has_k6_c = has_clique(adj, C, 6)
+    print("K5 full witness", k5)
+    print("has K6 full", has_k6)
+    print("has K6 on C", has_k6_c)
+    assert k5 is not None
+    assert not has_k6
+    assert not has_k6_c
+    b = B1[0]
+    NbC = [v for v in C if (adj[b] >> v) & 1]
+    has_k5_nbc = has_clique(adj, NbC, 5)
+    print("b", b, "NbC size", len(NbC), "has K5 on NbC", has_k5_nbc)
+    assert len(NbC) == 80
+    assert not has_k5_nbc
+    print("all exact verification checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/constants/28a.md
+++ b/constants/28a.md
@@ -60,24 +60,25 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 | $321$ | [[Pik2002](#Pik2002)] | Gives counterexamples in dimensions $321$ and $322$. <a href="#Bon2014-ub-improvements">[Bon2014-ub-improvements]</a> <a href="#Pik2002-ub-321-322">[Pik2002-ub-321-322]</a> |
 | $298$ | [[HR2003](#HR2003)] |  <a href="#Bon2014-ub-298">[Bon2014-ub-298]</a> |
 | $65$ | [[Bon2014](#Bon2014)] | Two-distance counterexample (416 points on $S^{64}\subset \mathbb{R}^{65}$); cannot be partitioned into $83$ smaller-diameter sets (so needs $\ge 84$). <a href="#Bon2014-ub-65">[Bon2014-ub-65]</a> |
-| $64$ | [[JB2014](#JB2014)] | Current best: a 352-point two-distance subset giving a counterexample in $\mathbb{R}^{64}$; cannot be partitioned into $70$ smaller-diameter sets (so needs $\ge 71$). <a href="#JB2014-ub-64">[JB2014-ub-64]</a> |
+| $64$ | [[JB2014](#JB2014)] | A 352-point two-distance subset giving a counterexample in $\mathbb{R}^{64}$; cannot be partitioned into $70$ smaller-diameter sets (so needs $\ge 71$). <a href="#JB2014-ub-64">[JB2014-ub-64]</a> |
+| $63$ | [[Gri2026](#Gri2026)] | Finite verification from the $G_2(4)$ graph: a $321$-point subset of $\mathbb{R}^{63}$ whose smaller-diameter subsets have size at most $5$, so at least $65>64$ parts are required. |
 
 ## Known lower bounds
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $4$ | [[Per1947](#Per1947)], [[Egg1955](#Egg1955)], [[Gru1957](#Gru1957)] | Borsuk’s conjecture is true for $n\le 3$. It remains open for $4\le n \le 63$. <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#WX2022-open-4-63">[WX2022-open-4-63]</a> |
+| $4$ | [[Per1947](#Per1947)], [[Egg1955](#Egg1955)], [[Gru1957](#Gru1957)] | Borsuk’s conjecture is true for $n\le 3$. After the $63$-dimensional construction, the first possible failing dimension remains open for $4\le n \le 62$. <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> |
 
 ## Additional comments and links
 
 - **Status of the “first failing dimension.”** At present,
   $$
-  4\ \le\ C_{28}\ \le\ 64,
+  4\ \le\ C_{28}\ \le\ 63,
   $$
-  and it is open whether the conjecture already fails in dimensions $4,5,\dots,63$; see the surveys [[Rai2004](#Rai2004)], [[Zon2021](#Zon2021)].
-  <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#WX2022-open-4-63">[WX2022-open-4-63]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a>
+  and it is open whether the conjecture already fails in dimensions $4,5,\dots,62$; see the surveys [[Rai2004](#Rai2004)], [[Zon2021](#Zon2021)].
+  <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a> <a href="#Gri2026">[Gri2026]</a>
 
-- **Two-distance counterexamples.** The currently best bounds $65$ and $64$ come from highly structured finite point sets with only two pairwise distances (equivalently, from certain strongly regular graphs); see [[Bon2014](#Bon2014)], [[JB2014](#JB2014)].
+- **Structured finite counterexamples.** The bounds $65$ and $64$ come from highly structured two-distance point sets associated to strongly regular graphs; the bound $63$ modifies the $G_2(4)$ construction by taking a $320$-point subset in a codimension-$2$ subspace and adding one scaled projected point. See [[Bon2014](#Bon2014)], [[JB2014](#JB2014)], and [[Gri2026](#Gri2026)].
   <a href="#Bon2014-ub-65">[Bon2014-ub-65]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a> <a href="#Bon2014-strongly-regular">[Bon2014-strongly-regular]</a>
 
 - **Asymptotic behavior of $b(n)$.** Kahn–Kalai [[KK1993](#KK1993)] showed that $b(n)$ can grow faster than $n+1$ (indeed at least $\exp(c\sqrt{n})$ for some $c>0$), implying failure of Borsuk’s conjecture in all sufficiently large dimensions.
@@ -112,6 +113,8 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 - <a id="Egg1955"></a>**[Egg1955]** Eggleston, H. G. *Covering a three-dimensional set with sets of smaller diameter.* Journal of the London Mathematical Society **30** (1955), 11–24. [Google Scholar](https://scholar.google.com/scholar?q=Eggleston+Covering+a+three-dimensional+set+with+sets+of+smaller+diameter+1955)
 
 - <a id="Gru1957"></a>**[Gru1957]** Grünbaum, Branko. *A simple proof of Borsuk’s conjecture in three dimensions.* Proceedings of the Cambridge Philosophical Society **53** (1957), 776–778. [Google Scholar](https://scholar.google.com/scholar?q=Gr%C3%BCnbaum+A+simple+proof+of+Borsuk%E2%80%99s+conjecture+in+three+dimensions+1957)
+
+- <a id="Gri2026"></a>**[Gri2026]** Grinsztajn, Max. *Finite verification of a $63$-dimensional counterexample to Borsuk's conjecture*, submitted to this repository (2026). Verification script: [`appendices/28_borsuk63_verification.py`](../appendices/28_borsuk63_verification.py).
 
 - <a id="Hin2002"></a>**[Hin2002]** Hinrichs, Aicke. *Spherical codes and Borsuk's conjecture.* Discrete Mathematics **243** (2002), 253–256. [Google Scholar](https://scholar.google.com/scholar?q=Hinrichs+Spherical+codes+and+Borsuk%27s+conjecture+2002)
 
@@ -178,4 +181,4 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 
 ## Contribution notes
 
-Prepared with assistance from ChatGPT 5.2 Pro.
+Prepared with assistance from ChatGPT 5.2 Pro. The $63$-dimensional update and verification script were prepared with assistance from Codex and GPT-5.5 Pro.


### PR DESCRIPTION
This PR updates the entry for the smallest dimension in which Borsuk's conjecture fails, improving the recorded upper bound

$$
C_{28}\le 64
$$

to

$$
C_{28}\le 63.
$$

The update is based on an exact finite verification from the $G_2(4)$ strongly regular graph. The new appendix script

```text
appendices/28_borsuk63_verification.py
```

reconstructs the graph from $PG(2,16)$, verifies the partition used below, and checks the clique obstruction.

## Verification summary

The script verifies:

```text
projective points 273
isotropic 65 nonisotropic 208
vertices 416
degrees [100] edges 20800
lambda [36] mu [20]
B size 96 C size 320
B component sizes [32, 32, 32]
B1 internal [20]
B1 to B2 [0]
B1 to B3 [0]
B1 to C [80]
B2 internal [20]
B2 to B1 [0]
B2 to B3 [0]
B2 to C [80]
B3 internal [20]
B3 to B1 [0]
B3 to B2 [0]
B3 to C [80]
C to B1 [8]
C to B2 [8]
C to B3 [8]
C internal [76]
K5 full witness [0, 122, 126, 130, 134]
has K6 full False
has K6 on C False
b 0 NbC size 80 has K5 on NbC False
all exact verification checks passed
```

## Proof details

Let $\Gamma$ be the $G_2(4)$ graph with parameters

$$
(v,k,\lambda,\mu)=(416,100,36,20).
$$

The appendix reconstructs $\Gamma$ over

$$
\mathbb F_{16}=\mathbb F_2[\alpha]/(\alpha^4+\alpha+1)
$$

as follows. The vertices are the $416$ unordered orthogonal bases of non-isotropic points in $PG(2,16)$, with respect to the Hermitian form

$$
h(u,w)=u_0w_0^4+u_1w_1^4+u_2w_2^4.
$$

For a vertex $A$, let $T(A)$ be the $15$ isotropic points on the three lines determined by the basis $A$. Two vertices are adjacent when

$$
|T(A)\cap T(A')|=3.
$$

The exact verification confirms that this gives a strongly regular graph with parameters $(416,100,36,20)$.

Use the standard Euclidean representation coming from the positive nontrivial eigenvalue $20$. Thus there are vectors $x_v\in\mathbb R^{65}$, $v\in V(\Gamma)$, with Gram matrix

$$
\langle x_u,x_v\rangle=
\begin{cases}
90, & u=v,\\
18, & u\sim v,\\
-6, & u\not\sim v.
\end{cases}
$$

Equivalently, the Gram matrix is

$$
G=96I+24A-6J,
$$

which has rank $65$, since the eigenvalues of $A$ are $100,20,-4$ with multiplicities $1,65,350$.

Fix an isotropic point $q_0$. Let $B$ be the set of vertices containing a non-isotropic point orthogonal to $q_0$. The script verifies that

$$
|B|=96
$$

and that the induced graph on $B$ has three connected components

$$
B_1,B_2,B_3
$$

of size $32$. Put

$$
C=V(\Gamma)\setminus B,
\qquad |C|=320.
$$

The verified equitable degrees are:

$$
\begin{aligned}
&|N(u)\cap B_i|=20 &&(u\in B_i),\\
&|N(u)\cap B_j|=0 &&(u\in B_i,\ i\ne j),\\
&|N(u)\cap C|=80 &&(u\in B),\\
&|N(c)\cap B_i|=8 &&(c\in C,\ i=1,2,3),\\
&|N(c)\cap C|=76 &&(c\in C).
\end{aligned}
$$

Let

$$
S_i=\sum_{y\in B_i}x_y.
$$

For every $c\in C$,

$$
\langle x_c,S_i\rangle
=8\cdot18+24\cdot(-6)=0.
$$

Also,

$$
\langle S_i,S_i\rangle
=32(90+20\cdot18+11\cdot(-6))=12288,
$$

while for $i\ne j$,

$$
\langle S_i,S_j\rangle=32^2(-6)=-6144.
$$

Thus the Gram matrix of $S_1,S_2,S_3$ has diagonal entries $12288$ and off-diagonal entries $-6144$, hence rank $2$. Therefore the points $x_c$, $c\in C$, lie in a subspace of dimension $65-2=63$.

Now choose $b\in B_1$, and set

$$
z_b=x_b-\frac1{32}S_1.
$$

Then $z_b$ is orthogonal to $S_1,S_2,S_3$, and

$$
\|z_b\|^2
=90-\frac{2}{32}\cdot384+\frac{1}{32^2}\cdot12288
=78.
$$

For $c\in C$, since $\langle S_1,x_c\rangle=0$, one has

$$
\langle z_b,x_c\rangle=\langle x_b,x_c\rangle
=
\begin{cases}
18, & b\sim c,\\
-6, & b\not\sim c.
\end{cases}
$$

Let

$$
t=\frac{\sqrt{222}-1}{13},
\qquad p=tz_b.
$$

Then $t$ satisfies

$$
78t^2+12t=102.
$$

Define

$$
X=\{x_c:c\in C\}\cup\{p\}.
$$

Then $X\subset\mathbb R^{63}$ and $|X|=321$. For $c,c'\in C$,

$$
\|x_c-x_{c'}\|^2=
\begin{cases}
144, & c\sim c',\\
192, & c\not\sim c',
\end{cases}
$$

and for $c\in C$,

$$
\|p-x_c\|^2=
\begin{cases}
192-48t, & b\sim c,\\
192, & b\not\sim c.
\end{cases}
$$

Thus $X$ has diameter squared $192$.

It remains to bound the size of a smaller-diameter part. The exact verification shows that $\Gamma$ has a $5$-clique but no $6$-clique. Hence any subset of $\{x_c:c\in C\}$ of diameter strictly smaller than $\sqrt{192}$ has at most $5$ points, since such a subset corresponds to a clique of $\Gamma$.

If a smaller-diameter part contains $p$, then every other point in that part must be $x_c$ with $c\in N(b)\cap C$, and these $c$'s must be pairwise adjacent. Adding $b$ gives a clique in $\Gamma$. Since $\Gamma$ has no $6$-clique, such a part again has at most $5$ points.

Therefore every part of diameter strictly smaller than $\operatorname{diam}(X)$ has at most $5$ points. Since

$$
|X|=321,
\qquad
\left\lceil\frac{321}{5}\right\rceil=65,
$$

any partition of $X$ into smaller-diameter parts requires at least $65$ parts. But in dimension $63$, Borsuk's conjecture would allow only $64$ parts. Hence Borsuk's conjecture fails in $\mathbb R^{63}$, and

$$
C_{28}\le63.
$$

## Files changed

- `README.md`: updates the upper bound for $C_{28}$ from $64$ to $63$.
- `constants/28a.md`: records the new $63$-dimensional construction and updates the comments.
- `appendices/28_borsuk63_verification.py`: exact finite verification script for the graph, partition, and clique checks.

AI assistance disclosure: the construction note and this submission were prepared with assistance from Codex and GPT-5.5 Pro; the finite checks in the appendix were rerun independently from the construction description.