### PR TITLE
Improve C45 upper bound for Romanoff's constant

### DIFF
--- a/constants/45a.md
+++ b/constants/45a.md
@@ -4,6 +4,12 @@
 
 $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers that can be expressed as the sum of a prime number and a power of two.
 
+Writing $A$ for this set, an explicit finite obstruction computation gives the upper-density bound
+$$
+\overline d(A)<0.490249407811155.
+$$
+[G2026-ub-0-490249407811155] If the density exists, this gives the corresponding upper bound for $C_{45}$.
+
 ## Known upper bounds
 
 | Bound | Reference | Comments |
@@ -12,6 +18,7 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 | $<0.5$ | [E1950] | Used covering systems |
 | $0.490941$ | [HR2006] | |
 | $0.490341088858244$ | [CDL2024] | |
+| $<0.490249407811155$ | [G2026] | 36-prime finite obstruction certificate with exact cluster-update verification. |
 
 ## Known lower bounds
 
@@ -23,6 +30,43 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 | $0.0936$ | [P2006] | |
 | $0.093627$ | [HS2010] | |
 | $0.107648$ | [CE2018] |  |
+
+
+## Certificate for the $0.490249407811155$ upper-density bound
+
+Let
+$$
+A=\{n\text{ odd}: n=p+2^k\text{ for some prime }p\text{ and }k\ge0\}.
+$$
+The certificate uses the finite prime set
+$$
+\begin{aligned}
+\mathcal P=\{&
+3,5,7,11,13,17,19,23,29,31,37,41,47,61,73,89,167,223,\\
+&233,263,359,383,431,439,479,1103,1433,1913,2089,2351,4513,\\
+&5737,8191,9719,176383,178481
+\}.
+\end{aligned}
+$$
+Put $M=\prod_{q\in\mathcal P}q$ and
+$T=\operatorname{lcm}_{q\in\mathcal P}\operatorname{ord}_q(2)$. For each residue class $a\pmod M$, let
+$$
+F(a)=\{r\pmod T:\gcd(a-2^r,M)=1\},\qquad \nu(a)=|F(a)|,
+$$
+and let $\delta(\nu)=\#\{a\pmod M:\nu(a)=\nu\}$.
+
+The obstruction argument gives
+$$
+\overline d(A)
+\le
+\sum_\nu
+\delta(\nu)
+\min\left(
+\frac1{2M},
+\frac{\nu}{T\varphi(M)\log 2}
+\right).
+$$
+The external verifier independently recomputes the 13-prime seed histogram from the residue conditions, applies the exact coprime-order cluster updates, and then evaluates the final rational upper bound using a rigorous lower bound for $\log 2$.
 
 
 ## Additional comments and links
@@ -42,7 +86,11 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 - [P2006] J. Pintz, "A note on Romanoff's constant," Acta Mathematica Hungarica, 112 (2006), 1-14.
 - [R1934] N. P. Romanoff, "Über einige Sätze der additiven Zahlentheorie," Math. Ann., 109 (1934), 668–678.
 
+- [G2026] Griego, Sebastian. 36-prime obstruction certificate for Romanoff's constant upper-density bound, 2026. [Code and verification](https://github.com/sebastian-griego/c45-romanoff-certificate/tree/v1-c45-certificate).
+- [G2026-ub-0-490249407811155] **loc:** external verifier repository, `verify_all.sh`. **quote:** "The exact rational verifier proves the upper-density bound \(\overline d(A)<0.490249407811155\)."
+
 
 ## Contribution notes
 
 Prepared with assistance from Gemini.
+This update was prepared with assistance from GPT-5.5 Pro; the construction, arithmetic, and verification script were reviewed by the human contributor.


### PR DESCRIPTION
## Summary

This updates `constants/45a.md` with a new upper-density bound for Romanoff's constant:

```text
overline d(A) < 0.490249407811155
```

The current page lists the CDL2024 upper bound

```text
0.490341088858244
```

so this lowers the displayed upper bound by

```text
0.000091681047089
```

## Mathematical certificate

Let

```text
A = {n odd : n = p + 2^k for some prime p and k >= 0}.
```

The certificate uses a finite set `P` of 36 odd primes. Let

```text
M = product_{q in P} q,
T = lcm_{q in P} ord_q(2).
```

For each residue class `a mod M`, define

```text
F(a) = {r mod T : gcd(a - 2^r, M) = 1},
nu(a) = |F(a)|,
delta(nu) = #{a mod M : nu(a) = nu}.
```

The obstruction is as follows. If `n = p + 2^k`, `n = a mod M`, and `k mod T` is not in `F(a)`, then some `q in P` divides `a - 2^k`. Hence `p = n - 2^k` is divisible by `q`, so the only possible exception is `p = q`. Those exceptional values lie in finitely many sets of the form `q + 2^k`, which have density zero.

Thus, up to density-zero exceptions, only the exponent classes in `F(a)` can contribute to residue class `a`. The prime number theorem in arithmetic progressions gives the upper-density estimate

```text
overline d(A) <= sum_nu delta(nu) min(1/(2M), nu/(T phi(M) log 2)).
```

The first term is the trivial density of odd integers in a residue class modulo `M`. The second term counts the admissible exponent classes and applies PNT in arithmetic progressions modulo the fixed modulus `M`.

The computation does not enumerate all residue classes modulo the full 36-prime product. Instead, the external verifier recomputes the 13-prime seed histogram from the residue conditions, then applies exact coprime-order cluster updates. For each added cluster of common order `d`, a finite polynomial records how many exponent classes remain admissible. Because the added orders are pairwise coprime and coprime to the base period, these updates factor by the Chinese remainder theorem and give the same histogram as direct enumeration.

## Verification

The reproducibility code is in a separate repository:

https://github.com/sebastian-griego/c45-romanoff-certificate/tree/v1-c45-certificate

Run:

```bash
./verify_all.sh
```

The verifier is split into two stages:

`generate_seed_histogram.cpp` recomputes the 13-prime seed histogram from the residue conditions, rather than hard-coding it.

`verify_c45_romanoff_upper_bound.py` reads that generated histogram, applies the exact coprime-order cluster updates, and checks the final rational inequality.

Expected output includes:

```text
36-prime Romanoff upper-density certificate
number of primes = 36
seed histogram entries = 2104
added multiplier entries = 302400
proved: upper density < 0.490249407811155
```

The scripts use exact integer and rational arithmetic for the proof. Decimal arithmetic is only used for display.

## Changed file

- `constants/45a.md`

## AI assistance disclosure

The construction, page update, PR text, and verification script were prepared with assistance from GPT-5.5 Pro. I reviewed and rechecked the construction, arithmetic, and verifier before submission.