### PR TITLE
Improve C28 upper bound to 63

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [26b](https://teorth.github.io/optimizationproblems/constants/26b.html) |Multilinear Bohnenblust--Hille constant (real) | $2$ | $\infty$ |
 | [27a](https://teorth.github.io/optimizationproblems/constants/27a.html) | Chromatic number of the plane | 5 | 7 |
 | [27b](https://teorth.github.io/optimizationproblems/constants/27b.html) | Maximum Chromatic Number of Biplanar Graphs | 9 | 12 |
-| [28](https://teorth.github.io/optimizationproblems/constants/28a.html) | Smallest dimension in which Borsuk’s conjecture fails | 4 | 64 |
+| [28](https://teorth.github.io/optimizationproblems/constants/28a.html) | Smallest dimension in which Borsuk’s conjecture fails | 4 | 63 |
 | [29](https://teorth.github.io/optimizationproblems/constants/29a.html) | Kissing number in dimension $5$ | 40 | 44 |
 | [30](https://teorth.github.io/optimizationproblems/constants/30a.html) | Stanley–Wilf limit for the permutation pattern $1324$ | 10.27 | 13.5 |
 | [31](https://teorth.github.io/optimizationproblems/constants/31a.html) | Chvátal–Sankoff constant for a binary alphabet | 0.792665992 (0.79970*) | 0.826280 |

--- a/constants/28a.md
+++ b/constants/28a.md
@@ -60,24 +60,25 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 | $321$ | [[Pik2002](#Pik2002)] | Gives counterexamples in dimensions $321$ and $322$. <a href="#Bon2014-ub-improvements">[Bon2014-ub-improvements]</a> <a href="#Pik2002-ub-321-322">[Pik2002-ub-321-322]</a> |
 | $298$ | [[HR2003](#HR2003)] |  <a href="#Bon2014-ub-298">[Bon2014-ub-298]</a> |
 | $65$ | [[Bon2014](#Bon2014)] | Two-distance counterexample (416 points on $S^{64}\subset \mathbb{R}^{65}$); cannot be partitioned into $83$ smaller-diameter sets (so needs $\ge 84$). <a href="#Bon2014-ub-65">[Bon2014-ub-65]</a> |
-| $64$ | [[JB2014](#JB2014)] | Current best: a 352-point two-distance subset giving a counterexample in $\mathbb{R}^{64}$; cannot be partitioned into $70$ smaller-diameter sets (so needs $\ge 71$). <a href="#JB2014-ub-64">[JB2014-ub-64]</a> |
+| $64$ | [[JB2014](#JB2014)] | A 352-point two-distance subset giving a counterexample in $\mathbb{R}^{64}$; cannot be partitioned into $70$ smaller-diameter sets (so needs $\ge 71$). <a href="#JB2014-ub-64">[JB2014-ub-64]</a> |
+| $63$ | [[Gri2026](#Gri2026)] | Current best: a $321$-point subset of $\mathbb{R}^{63}$ whose smaller-diameter subsets have size at most $5$, so at least $65>64$ parts are required. |
 
 ## Known lower bounds
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $4$ | [[Per1947](#Per1947)], [[Egg1955](#Egg1955)], [[Gru1957](#Gru1957)] | Borsuk’s conjecture is true for $n\le 3$. It remains open for $4\le n \le 63$. <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#WX2022-open-4-63">[WX2022-open-4-63]</a> |
+| $4$ | [[Per1947](#Per1947)], [[Egg1955](#Egg1955)], [[Gru1957](#Gru1957)] | Borsuk’s conjecture is true for $n\le 3$. After the $63$-dimensional construction, the first possible failing dimension remains open for $4\le n \le 62$. <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> |
 
 ## Additional comments and links
 
 - **Status of the “first failing dimension.”** At present,
   $$
-  4\ \le\ C_{28}\ \le\ 64,
+  4\ \le\ C_{28}\ \le\ 63,
   $$
-  and it is open whether the conjecture already fails in dimensions $4,5,\dots,63$; see the surveys [[Rai2004](#Rai2004)], [[Zon2021](#Zon2021)].
-  <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#WX2022-open-4-63">[WX2022-open-4-63]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a>
+  and it is open whether the conjecture already fails in dimensions $4,5,\dots,62$; see the surveys [[Rai2004](#Rai2004)], [[Zon2021](#Zon2021)].
+  <a href="#WX2022-lb-nle3">[WX2022-lb-nle3]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a> <a href="#Gri2026">[Gri2026]</a>
 
-- **Two-distance counterexamples.** The currently best bounds $65$ and $64$ come from highly structured finite point sets with only two pairwise distances (equivalently, from certain strongly regular graphs); see [[Bon2014](#Bon2014)], [[JB2014](#JB2014)].
+- **Structured finite counterexamples.** The bounds $65$ and $64$ come from highly structured two-distance point sets associated to strongly regular graphs. The bound $63$ modifies the $G_2(4)$ construction by taking a $320$-point subset in a codimension-$2$ subspace and adding one scaled projected point. See [[Bon2014](#Bon2014)], [[JB2014](#JB2014)], and [[Gri2026](#Gri2026)].
   <a href="#Bon2014-ub-65">[Bon2014-ub-65]</a> <a href="#JB2014-ub-64">[JB2014-ub-64]</a> <a href="#Bon2014-strongly-regular">[Bon2014-strongly-regular]</a>
 
 - **Asymptotic behavior of $b(n)$.** Kahn–Kalai [[KK1993](#KK1993)] showed that $b(n)$ can grow faster than $n+1$ (indeed at least $\exp(c\sqrt{n})$ for some $c>0$), implying failure of Borsuk’s conjecture in all sufficiently large dimensions.
@@ -112,6 +113,8 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 - <a id="Egg1955"></a>**[Egg1955]** Eggleston, H. G. *Covering a three-dimensional set with sets of smaller diameter.* Journal of the London Mathematical Society **30** (1955), 11–24. [Google Scholar](https://scholar.google.com/scholar?q=Eggleston+Covering+a+three-dimensional+set+with+sets+of+smaller+diameter+1955)
 
 - <a id="Gru1957"></a>**[Gru1957]** Grünbaum, Branko. *A simple proof of Borsuk’s conjecture in three dimensions.* Proceedings of the Cambridge Philosophical Society **53** (1957), 776–778. [Google Scholar](https://scholar.google.com/scholar?q=Gr%C3%BCnbaum+A+simple+proof+of+Borsuk%E2%80%99s+conjecture+in+three+dimensions+1957)
+
+- <a id="Gri2026"></a>**[Gri2026]** Grinsztajn, Max. *A $63$-dimensional counterexample to Borsuk's conjecture* (2026). Proof PDF, verification script, exported DIMACS certificates, and optional Sage verification of the exported certificates: [GitHub repository](https://github.com/maaxgrin/borsuk-63-counterexample).
 
 - <a id="Hin2002"></a>**[Hin2002]** Hinrichs, Aicke. *Spherical codes and Borsuk's conjecture.* Discrete Mathematics **243** (2002), 253–256. [Google Scholar](https://scholar.google.com/scholar?q=Hinrichs+Spherical+codes+and+Borsuk%27s+conjecture+2002)
 
@@ -178,4 +181,4 @@ If Borsuk’s conjecture were true in all dimensions, we would set $C_{28}=\inft
 
 ## Contribution notes
 
-Prepared with assistance from ChatGPT 5.2 Pro.
+Prepared with assistance from ChatGPT 5.5 Pro.


### PR DESCRIPTION
This PR records a construction of a counterexample to Borsuk's conjecture in dimension $63$. Equivalently, it improves the recorded upper bound for $C_{28}$ from

$$
C_{28}\le 64
$$

to

$$
C_{28}\le 63.
$$

The construction starts from the standard $G_2(4)$ Euclidean representation used in the Bondarenko and Jenrich--Brouwer constructions. The new step is to remove a structured set of $96$ points so that the remaining $320$ points lie in a $63$-dimensional subspace, then adjoin one projected point while preserving the clique obstruction: every subset of smaller diameter has size at most $5$.

The proof PDF, verification script, exported DIMACS certificates, and optional Sage verification of the exported certificates are available here:

https://github.com/maaxgrin/borsuk-63-counterexample

The construction and proof were obtained with assistance from GPT-5.5 Pro.




