### PR TITLE
Improve C42 upper bound to 0.6906538

### DIFF
--- a/constants/42a.md
+++ b/constants/42a.md
@@ -13,6 +13,7 @@ where the minimum is taken over all $z_1,\ldots,z_n\in \mathbb{C}$ with $\max_i 
 | 1 | Trivial |  |
 | 5/6 | Biró [Bir00] | |
 | 0.69368 | Harcos [Bir00] | |
+| 0.6906538* | Griego [Gri26] | Proposed asymptotic two-block certificate with exact rational interval verification of the limiting inequality. No explicit finite threshold $N$ is supplied. |
 
 ## Known lower bounds
 
@@ -37,3 +38,8 @@ where the minimum is taken over all $z_1,\ldots,z_n\in \mathbb{C}$ with $\max_i 
 - [Bir00] Biró, A. *An upper estimate in Tur\'{a}n's pure power sum problem.* Indag. Math. (N.S.) **11** (2000), no. 4, 499-508.
 - [Bir00b] Biró, A. *An improved estimate in a power sum problem of Tur\'{a}n.* Indag. Math. (N.S.) **11** (2000), no. 3, 343-358.
 - [CG96] A. Y. Cheer and D. A. Goldston *Tur\'{a}n's pure power sum problem.* Math. Comp. **65** (1996), no. 215, 1349-1358.
+- [Gri26] Griego, S. *An improved asymptotic certificate for Turan's pure power sum constant $C_{42}$.* GitHub repository, version `v1.0.0`, commit `c8ddce14d9a5e898406d5dc6b8d08bb8a39507c7` (2026). https://github.com/sebastian-griego/turan-c42-certificate/tree/v1.0.0
+
+## Contribution notes
+
+The [Gri26] certificate repository and this update were prepared with AI assistance for formatting, exposition, and verification scripts. The mathematical claim, constants, references, and computations are provided for independent review.


### PR DESCRIPTION
This PR records a proposed asymptotic certificate for Turan's pure power sum constant $C_{42}$. It improves the recorded upper bound from

$$
C_{42}\le 0.69368
$$

to

$$
C_{42}\le 0.6906538.
$$

The proof is asymptotic and does not provide an explicit finite threshold $N$. The exact verifier checks the limiting numerical certificate using rational interval arithmetic; the asymptotic reduction is proved in the accompanying note.

The proof note, exact verifier, exported certificate data, transcript, CI workflow, and optional exported-certificate consistency checker are available here:

https://github.com/sebastian-griego/turan-c42-certificate/tree/v1.0.0

I marked the bound with an asterisk because it is supported by a reviewable certificate but has not been independently reviewed or formalized.

AI assistance was used for formatting, exposition, and preparation of verification scripts. The mathematical claim, constants, references, and computations are provided for independent review.