### PR TITLE
Improve C10c lower bound to 5/3

### DIFF
--- a/constants/10c.md
+++ b/constants/10c.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{10c}$ is the least constant $K$ for which one has
+$C\_{10c}$ is the least constant $K$ for which one has
 
 $$
 \mathrm{disc}(A) \le K\sqrt{n}
@@ -280,7 +280,7 @@ $$
 ## Further remarks
 
 - For large $n$, the best asymptotic lower bound remains $1$ [Band2024].
-- Replacing the entrywise bound by an $\ell_2$-bound on columns leads to the Komlós conjecture, which would imply, after scaling, Spencer-type discrepancy bounds.
+- Replacing the entrywise bound by an $\ell\_2$-bound on columns leads to the Komlós conjecture, which would imply, after scaling, Spencer-type discrepancy bounds.
 
 ## References
 

--- a/constants/10c.md
+++ b/constants/10c.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C\_{10c}$ is the least constant $K$ for which one has
+$C_{10c}$ is the least constant $K$ for which one has
 
 $$
 \mathrm{disc}(A) \le K\sqrt{n}
@@ -45,6 +45,7 @@ $$
 | $1$ | Trivial | $A=[1]$. Also achieved by Hadamard matrices [Band2024]. |
 | $\sqrt{2}\approx 1.414214$ | [Band2024] | The 2 by 2 sign matrix with rows $(1,1)$ and $(1,-1)$. |
 | $4/\sqrt{6}\approx 1.632993$ | [G2026] | A 6 by 6 sign matrix with exact discrepancy $4$. |
+| $5/3\approx 1.666667$ | [X2026] | A 9 by 9 sign matrix with exact discrepancy $5$. |
 
 ## Certificate for the $4/\sqrt{6}$ lower bound
 
@@ -148,10 +149,138 @@ $$
 C_{10c}\ge \frac{4}{\sqrt{6}}\approx 1.632993.
 $$
 
+## Certificate for the $5/3$ lower bound
+
+Use the following sign matrix:
+
+```text
+ 1   1   1   1   1   1   1   1   1
+-1  -1  -1   1   1   1   1   1   1
+-1   1   1  -1  -1   1   1   1   1
+ 1  -1  -1  -1  -1   1   1   1   1
+ 1  -1   1  -1   1  -1   1   1   1
+-1   1  -1  -1   1  -1   1   1   1
+-1  -1   1   1  -1  -1   1   1   1
+ 1   1  -1   1  -1  -1   1   1   1
+ 1   1   1   1   1   1   1   1   1
+```
+
+All entries are $\pm 1$. The ninth row is a duplicate of the first row; duplicate rows are allowed, and here it simply makes the displayed certificate square. This is a padding step in the row direction only: the construction still has nine columns, so it is not an $8$ by $8$ certificate.
+
+For a sign vector $x$, let $S$ be the set of columns where the corresponding coordinate of $x$ is $-1$. For row number $i$, let $T_i$ be the set of columns where that row has entry $-1$:
+
+```text
+T1 = {}
+T2 = {1,2,3}
+T3 = {1,4,5}
+T4 = {2,3,4,5}
+T5 = {2,4,6}
+T6 = {1,3,4,6}
+T7 = {1,2,5,6}
+T8 = {3,5,6}
+T9 = {}
+```
+
+Then
+
+$$
+(Ax)_i = 9 - 2\lvert S\triangle T_i\rvert.
+$$
+
+Therefore the absolute value of the $i$th coordinate of $Ax$ is at least $5$ whenever $S$ is within Hamming distance $2$ of either $T_i$ or the complement of $T_i$.
+
+We now prove this covering condition for the full $9$-cube. Write
+
+$$
+S=U\cup W,
+$$
+
+where
+
+$$
+U\subseteq\{1,\dots,6\},\qquad W\subseteq\{7,8,9\}.
+$$
+
+Let $w=\lvert W\rvert$. Since all the sets $T_i$ above are contained in $\{1,\dots,6\}$, for $i=1,\dots,8$ write $T_i=C_i$, where
+
+```text
+C = {}, 123, 145, 2345, 246, 1346, 1256, 356
+```
+
+Let $C_i^*$ denote the complement of $C_i$ inside $\{1,\dots,6\}$. Then the complement of $T_i$ inside $\{1,\dots,9\}$ is
+
+$$
+T_i^c=C_i^*\cup\{7,8,9\}.
+$$
+
+Thus the relevant distances in the full $9$-cube are
+
+$$
+d_9(S,T_i)=d_6(U,C_i)+w
+$$
+
+and
+
+$$
+d_9(S,T_i^c)=d_6(U,C_i^*)+(3-w).
+$$
+
+The last three coordinates are therefore accounted for by the terms $w$ and $3-w$.
+
+The following finite fact about the $6$-cube will be used. The eight radius-$1$ balls around
+
+```text
+C = {}, 123, 145, 2345, 246, 1346, 1256, 356
+```
+
+miss exactly the eight complements
+
+```text
+C* = 123456, 456, 236, 16, 135, 25, 34, 124
+```
+
+Indeed, the codewords in $C$ have mutual Hamming distance at least $3$, so their radius-$1$ balls are disjoint and contain $8(1+6)=56$ vertices. Each listed vertex in $C^*$ has distance at least $2$ from every codeword in $C$, so none is in these balls. Since the $6$-cube has $64$ vertices, these are exactly the eight missed vertices.
+
+The missed vertices are nevertheless within radius $2$ of $C$; respectively, one may use the following centers:
+
+```text
+missed vertex:    123456  456  236  16    135  25    34    124
+radius-2 center:  2345    246  123  1346  356  1256  2345  123
+```
+
+Now consider the four possible values of $w=\lvert W\rvert$.
+
+If $w=0$, then $d_9(S,T_i)=d_6(U,C_i)$. The radius-$2$ covering of the $6$-cube by $C$ gives some $i$ with $d_9(S,T_i)\le 2$.
+
+If $w=1$, then $d_9(S,T_i)=d_6(U,C_i)+1$ and $d_9(S,T_i^c)=d_6(U,C_i^*)+2$. By the radius-$1$ statement above, either $U$ is within distance $1$ of some $C_i$, which gives $d_9(S,T_i)\le 2$, or $U=C_i^*$ for some $i$, which gives $d_9(S,T_i^c)=2$.
+
+If $w=2$, apply the previous $w=1$ case to the complement of $S$. Equivalently, either $U=C_i$ for some $i$, giving $d_9(S,T_i)=2$, or $U$ is within distance $1$ of some $C_i^*$, giving $d_9(S,T_i^c)\le 2$.
+
+If $w=3$, then $d_9(S,T_i^c)=d_6(U,C_i^*)$. By applying the radius-$2$ covering of the $6$-cube by $C$ to the complement of $U$, the complements $C_i^*$ also form a radius-$2$ covering of the $6$-cube. Hence some $i$ satisfies $d_9(S,T_i^c)\le 2$.
+
+Thus every vertex $S$ of the full $9$-cube is within Hamming distance $2$ of some $T_i$ or of some complement $T_i^c$. Consequently every sign vector satisfies
+
+$$
+\|Ax\|_\infty\ge 5.
+$$
+
+Equality is attained. For example,
+
+```text
+x  = (-1,-1,1,-1,1,1,1,1,1)^T
+Ax = (3,5,5,3,5,3,3,-3,3)^T
+```
+
+Hence $\mathrm{disc}(A)=5$, and consequently
+
+$$
+C_{10c}\ge \frac{5}{\sqrt{9}}=\frac{5}{3}\approx 1.666667.
+$$
+
 ## Further remarks
 
 - For large $n$, the best asymptotic lower bound remains $1$ [Band2024].
-- Replacing the entrywise bound by an $\ell\_2$-bound on columns leads to the Komlós conjecture, which would imply, after scaling, Spencer-type discrepancy bounds.
+- Replacing the entrywise bound by an $\ell_2$-bound on columns leads to the Komlós conjecture, which would imply, after scaling, Spencer-type discrepancy bounds.
 
 ## References
 
@@ -164,6 +293,7 @@ $$
 - [MO175826] MathOverflow. [*Spencer’s “six standard deviations” theorem – better constants?*](https://mathoverflow.net/questions/175826/) Question 175826 (2014).
 - [PV2022] Pesenti, L.; Vladu, A. *Discrepancy Minimization via Regularization.* [arXiv:2211.05509](https://arxiv.org/abs/2211.05509)
 - [Spe1985] Spencer, J. *Six standard deviations suffice.* Trans. Amer. Math. Soc. **289** (2) (1985), 679–706.
+- [X2026] Xie, Chuhan. 9 by 9 sign-matrix certificate for C10c, submitted to this repository (2026).
 
 ## Contribution notes
 


### PR DESCRIPTION
## Summary

This PR updates `constants/10c.md` with a finite-dimensional certificate giving

$$
C_{10c} \ge 5/3 \approx 1.666667.
$$

The certificate uses a $9$ by $9$ sign matrix $A$ with exact discrepancy

$$
\mathrm{disc}(A)=5.
$$

Thus

$$
\frac{\mathrm{disc}(A)}{\sqrt{9}}=\frac{5}{3}.
$$

This improves the lower bound $4/\sqrt{6}\approx 1.632993$.

## Certificate

Use the following $9$ by $9$ sign matrix:

```text
 1   1   1   1   1   1   1   1   1
-1  -1  -1   1   1   1   1   1   1
-1   1   1  -1  -1   1   1   1   1
 1  -1  -1  -1  -1   1   1   1   1
 1  -1   1  -1   1  -1   1   1   1
-1   1  -1  -1   1  -1   1   1   1
-1  -1   1   1  -1  -1   1   1   1
 1   1  -1   1  -1  -1   1   1   1
 1   1   1   1   1   1   1   1   1
```

Let $T_i\subseteq\{1,\ldots,9\}$ be the set of columns where row $i$ has entry $-1$:

```text
T1 = {}
T2 = {1,2,3}
T3 = {1,4,5}
T4 = {2,3,4,5}
T5 = {2,4,6}
T6 = {1,3,4,6}
T7 = {1,2,5,6}
T8 = {3,5,6}
T9 = {}
```

The ninth row is a duplicate of the first row; duplicate rows are allowed, and here it simply makes the displayed certificate square.

For $x\in\{\pm 1\}^9$, let $S\subseteq\{1,\ldots,9\}$ be the set of columns where $x_j=-1$.  Then

$$
(Ax)_i = 9-2\lvert S\triangle T_i\rvert.
$$

Hence $\lvert (Ax)_i\rvert\ge 5$ if either

$$
\lvert S\triangle T_i\rvert\le 2,
$$

or

$$
\lvert S\triangle T_i^{c}\rvert\le 2,
$$

where complements are taken in $\{1,\ldots,9\}$.  It is therefore enough to prove that every vertex $S$ of the full $9$-cube is within Hamming distance $2$ of some $T_i$ or some complement $T_i^{c}$.

### Full 9-cube covering proof

Although the useful structure is six-dimensional, the covering statement below is for all $2^9$ vertices of the $9$-cube.

Write

$$
S=U\cup W,
$$

where

$$
U\subseteq\{1,\ldots,6\},\qquad W\subseteq\{7,8,9\}.
$$

Let $w=\lvert W\rvert$.  Since all the sets $T_i$ above are contained in $\{1,\ldots,6\}$, for $i=1,\ldots,8$ we may write $T_i=C_i$, where

```text
C = {}, 123, 145, 2345, 246, 1346, 1256, 356
```

Let $C_i^{\ast}$ denote the complement of $C_i$ inside $\{1,\ldots,6\}$.  Then the complement of $T_i$ inside $\{1,\ldots,9\}$ is

$$
T_i^{c}=C_i^{\ast}\cup\{7,8,9\}.
$$

Therefore the two relevant distances in the full $9$-cube are exactly

$$
d_9(S,T_i)=d_6(U,C_i)+w
$$

and

$$
d_9(S,T_i^{c})=d_6(U,C_i^{\ast})+(3-w).
$$

So the last three coordinates are not being ignored; they appear through the terms $w$ and $3-w$.

We now record the finite $6$-cube fact used in the four cases below.  The eight radius-1 balls around

```text
C = {}, 123, 145, 2345, 246, 1346, 1256, 356
```

miss exactly the eight complements

```text
C* = 123456, 456, 236, 16, 135, 25, 34, 124
```

Indeed, the codewords in $C$ have mutual Hamming distance at least $3$, so their radius-1 balls are disjoint and contain $8(1+6)=56$ vertices.  Each listed vertex in $C^{\ast}$ has distance at least $2$ from every codeword in $C$, so none is in these balls.  Since the $6$-cube has $64$ vertices, these are exactly the $8$ missed vertices.

The missed vertices are nevertheless within radius $2$ of $C$; respectively, one may use the following centers:

```text
missed vertex:   123456   456   236   16    135   25    34    124
radius-2 center: 2345     246   123   1346  356   1256  2345  123
```

Now consider the four possible values of $w=\lvert W\rvert$.

If $w=0$, then $d_9(S,T_i)=d_6(U,C_i)$.  The radius-2 covering of the $6$-cube by $C$ gives some $i$ with $d_9(S,T_i)\le 2$.

If $w=1$, then $d_9(S,T_i)=d_6(U,C_i)+1$ and $d_9(S,T_i^{c})=d_6(U,C_i^{\ast})+2$.  By the radius-1 statement above, either $U$ is within distance $1$ of some $C_i$, which gives $d_9(S,T_i)\le 2$, or $U=C_i^{\ast}$ for some $i$, which gives $d_9(S,T_i^{c})=2$.

If $w=2$, apply the previous $w=1$ case to the complement of $S$.  Equivalently, either $U=C_i$ for some $i$, giving $d_9(S,T_i)=2$, or $U$ is within distance $1$ of some $C_i^{\ast}$, giving $d_9(S,T_i^{c})\le 2$.

If $w=3$, then $d_9(S,T_i^{c})=d_6(U,C_i^{\ast})$.  By applying the radius-2 covering of the $6$-cube by $C$ to the complement of $U$, the complements $C_i^{\ast}$ also form a radius-2 covering of the $6$-cube.  Hence some $i$ satisfies $d_9(S,T_i^{c})\le 2$.

Thus every vertex $S$ of the full $9$-cube is within Hamming distance $2$ of some $T_i$ or some $T_i^{c}$.  Consequently every sign vector $x\in\{\pm 1\}^9$ satisfies

$$
\|Ax\|_\infty\ge 5.
$$

Equality is attained.  For example, with

```text
x = (-1,-1,1,-1,1,1,1,1,1)^T
```

one obtains

```text
Ax = (3,5,5,3,5,3,3,-3,3)^T.
```

Therefore $\mathrm{disc}(A)=5$, and consequently

$$
C_{10c}\ge\frac{5}{\sqrt{9}}=\frac{5}{3}\approx 1.666667.
$$

## Verification

The certificate was also checked by exhaustive enumeration of all $2^9=512$ sign vectors.  A minimal verification script is:

```javascript
const n = 9;
const centers = [
  [],
  [1,2,3],
  [1,4,5],
  [2,3,4,5],
  [2,4,6],
  [1,3,4,6],
  [1,2,5,6],
  [3,5,6],
  [],
];

function mask(set) {
  return set.reduce((m, j) => m | (1 << (j - 1)), 0);
}

function popcount(x) {
  let c = 0;
  while (x) {
    x &= x - 1;
    c++;
  }
  return c;
}

function setString(m) {
  const out = [];
  for (let j = 1; j <= n; j++) {
    if (m & (1 << (j - 1))) out.push(j);
  }
  return `{${out.join(",")}}`;
}

const T = centers.map(mask);
const fullMask = (1 << n) - 1;
let best = Infinity;
let bestS = null;
let bestVals = null;
let uncovered = [];

for (let S = 0; S < (1 << n); S++) {
  const vals = T.map(t => n - 2 * popcount(S ^ t));
  const discrepancy = Math.max(...vals.map(v => Math.abs(v)));
  if (discrepancy < best) {
    best = discrepancy;
    bestS = S;
    bestVals = vals;
  }
  const covered = T.some(t =>
    Math.min(popcount(S ^ t), popcount(S ^ (t ^ fullMask))) <= 2
  );
  if (!covered) uncovered.push(setString(S));
}

console.log({
  best,
  bestS: setString(bestS),
  bestVals,
  ratio: best / Math.sqrt(n),
  uncoveredByRadius2AntipodalBalls: uncovered,
});
```

It returns

```text
best: 5
bestS: {1,2,4}
bestVals: [3, 5, 5, 3, 5, 3, 3, -3, 3]
ratio: 1.6666666666666667
uncoveredByRadius2AntipodalBalls: []
```

## Changed file

- `constants/10c.md`

## AI assistance disclosure

Codex was used to search for and verify the certificate and to draft this PR text.
