### PR TITLE
Improve C82 upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [79](https://teorth.github.io/optimizationproblems/constants/79a.html) | Asymptotic essential-dimension ratio of the symmetric groups | $\frac{1}{2}$ | 1 |
 | [80](https://teorth.github.io/optimizationproblems/constants/80a.html) | Ising perceptron capacity threshold | >0 (0.833*) | 0.847 (0.833*) |
 | [81](https://teorth.github.io/optimizationproblems/constants/81a.html) | Brun's constant | 1.840503 | 2.288513 |
-| [82](https://teorth.github.io/optimizationproblems/constants/82a.html) | Essential minimum of the Zhang-Zagier height | 0.24874 | 0.25444 |
+| [82](https://teorth.github.io/optimizationproblems/constants/82a.html) | Essential minimum of the Zhang-Zagier height | 0.24874 | 0.2536331090204145 |
 | [83](https://teorth.github.io/optimizationproblems/constants/83a.html) | Wirsing Constant | 0.30366300 | 0.30366300 |
 | [84a](https://teorth.github.io/optimizationproblems/constants/84a.html) | Erdős unit distance exponent | 1.014 (1.03583*) | $\frac{4}{3}\approx 1.3333$ |
 | [84b](https://teorth.github.io/optimizationproblems/constants/84b.html) | Sum-product exponent for the reals | $\frac{4}{3}+\frac{10}{4407}\approx 1.3356$ | $<2$ (1.999281*) |

--- a/constants/82a.md
+++ b/constants/82a.md
@@ -22,7 +22,7 @@ h_Z(\alpha)\le H\}$ is finite.
 |0.39679 | [D03], Section 7 |  |
 | 0.25594 | [Doc01a] |  $h_Z=\log \mathfrak{h}$ in his notation |
 | 0.25444 | [Doc01b] | Previous best known upper bound |
-| 0.2536331090204145 | [Gri26] | Certified computation based on Doche's polynomials |
+| 0.2536331090204145 | [Gri26] | Computation based on Doche's polynomials |
 
 ## Known lower bounds
 

--- a/constants/82a.md
+++ b/constants/82a.md
@@ -21,7 +21,8 @@ h_Z(\alpha)\le H\}$ is finite.
 | ----- | --------- | -------- |
 |0.39679 | [D03], Section 7 |  |
 | 0.25594 | [Doc01a] |  $h_Z=\log \mathfrak{h}$ in his notation |
-| 0.25444 | [Doc01b] | Best known upper bound |
+| 0.25444 | [Doc01b] | Previous best known upper bound |
+| 0.2536331090204145 | [Gri26] | Certified computation based on Doche's polynomials |
 
 ## Known lower bounds
 
@@ -60,6 +61,10 @@ Math. Comp. 72 (2003), no. 243, 1487–1499
 - [F18] Flammang, V.
 On the Zhang-Zagier measure.
 Int. J. Number Theory 14 (2018), no. 10, 2663–2671
+- [Gri26] Max Grinsztajn.
+Code and certification data for an improved C82 Zhang-Zagier bound.
+GitHub repository, 2026.
+https://github.com/maaxgrin/zhang-zagier-c82-bound
 - [S80] Smyth, C. J.
 On the measure of totally real algebraic integers.
 J. Austral. Math. Soc. Ser. A 30 (1980/81), no. 2, 137–149.
@@ -69,3 +74,7 @@ Math. Comp. 61 (1993), no. 203, 485–491.
 - [Zha95] Zhang, S.
 Positive line bundles on arithmetic varieties.
 J. Amer. Math. Soc. 8 (1995), no. 1, 187–221.
+
+## Contribution notes
+
+Prepared with assistance from GPT-5.5 Pro.


### PR DESCRIPTION
This PR improves the recorded upper bound for C82, the essential minimum of the Zhang--Zagier height, from

```text
C82 <= 0.25444
```

to the certified bound

```text
C82 <= 0.2536331090204145.
```

The construction uses the polynomials P1,...,P9,Q1,Q2 introduced by C. Doche in *Zhang-Zagier heights of perturbed polynomials*, J. Theor. Nombres Bordeaux 13 (2001), no. 1, 103--110. Starting from Q1,Q2, the computation adds the perturbative factors

```text
R0 = Q1 - P1^5 P2^5 P4 P8,
R2 = Q2 + P1^5 P2^5 P4 P7.
```

The final denominator is

```text
Q = Q1 * Q2 * R0 * R2 * P7 * P9.
```

For this Q, optimizing the perturbative numerator exponents gives the numerical value `0.253626920959`; the interval-certified upper bound is `0.2536331090204145`.

The code, tests, certification run, and finite-family search report are available here:

https://github.com/maaxgrin/zhang-zagier-c82-bound
