### PR TITLE
Improve C1a lower bound to 1.292

### DIFF
--- a/constants/1a.md
+++ b/constants/1a.md
@@ -32,6 +32,7 @@ for all non-negative $f \colon \mathbb{R} \to \mathbb{R}$.
 | $1.2748$ | [MV2009] | |
 | $1.28$ | [CS2017] | |
 | $1.2802$ | [XX2026] | Unpublished improvement, Grok|
+| $1.292$ | [PBV2026] | |
 
 
 ## Additional comments and links
@@ -46,6 +47,7 @@ for all non-negative $f \colon \mathbb{R} \to \mathbb{R}$.
 - [MO2004] Martin, Greg; O’Bryant, Kevin. The symmetric subset problem in continuous Ramsey theory. Exp. Math. 16, No. 2, 145-165 (2007). [arXiv:math/0410004](https://arxiv.org/abs/math/0410004)
 - [MO2009] Martin, Greg; O’Bryant, Kevin. The supremum of autoconvolutions, with applications to additive number theory. Ill. J. Math. 53, No. 1, 219-235 (2009). [arXiv:0807.5121](https://arxiv.org/abs/0807.5121)
 - [MV2009] Matolcsi, Máté; Vinuesa, Carlos. Improved bounds on the supremum of autoconvolutions. J. Math. Anal. Appl. 372, No. 2, 439-447 (2010). [arXiv:0907.1379](https://arxiv.org/abs/0907.1379)
+- [PBV2026] Piterbarg, Andrei; Bajaj, Jai; Vincent, Derrick. A multi-scale arcsine lower bound for the Sidon autocorrelation constant $C\_{1a}$, 2026. https://github.com/AndreiPiterbarg/sidon-autocorrelation
 - [SS2002] Schinzel, A.; Schmidt, W. M.. Comparison of $L^1$ and $L^\infty$ norms of squares of polynomials. Acta Arith. 104, No. 3, 283-296 (2002).
 - [WSZXRYHHMPCHCWDS2025] Wang, Yiping; Su, Shao-Rong; Zeng, Zhiyuan; Xu, Eva; Ren, Liliang; Yang, Xinyu; Huang, Zeyi; He, Pengcheng; Cheng, Hao; Chen, Weizhu; Wang, Shuohang; Du, Simon Shaolei; Shen, Yelong. ThetaEvolve: Test-time Learning on Open Problems. [arXiv:2511.23473](https://arxiv.org/abs/2511.23473)
 - [XX2026] Xie, Xinyuan. Unpublished improvement to the lower bound for $C_{1a}$ (claiming $C_{1a} \ge 1.2802$). 2026. See [Grok chat](https://grok.com/share/c2hhcmQtNQ_f4d17f80-4582-4679-b931-06277fd4cfd4?rid=a60436ae-eaba-4638-a0fd-47b231f19cd0).


### PR DESCRIPTION
This updates the lower bound for the Sidon autocorrelation constant $C_{1a}$ to **1.292**.

The bound is obtained from a three-scale arcsine kernel combined with a reoptimized Fejér-side majorant, applied to the Matolcsi–Vinuesa master inequality. The analytic argument — including the reduction from the full nonnegative $L^1$ class — is formalized in Lean 4, and the numerical anchors (the kernel's $L^2$ norm, the gain functional, the majorant minimum, and lattice positivity) are certified by `flint.arb` interval arithmetic at 256-bit precision.

Full details, the Lean formalization, and the certificates are available in the repository: https://github.com/AndreiPiterbarg/sidon-autocorrelation

This submission was prepared with AI assistance; all references and results have been reviewed and verified by the authors.
