### PR TITLE
Improve lower bound for C_3b

### DIFF
--- a/constants/3b.md
+++ b/constants/3b.md
@@ -25,6 +25,7 @@ $$ A \stackrel{G}{\pm} B := \{ a \pm b: a \in A, b \in B\}.$$
 | $\frac{\log 27}{\log (27/4)} = 1.72598\dots$ | Ruzsa (unpublished) | |
 | $1.77898$ | [L2015] | |
 | $>1.77898$ | [GGSWT2025] | Improved [L2015] in the eighth decimal place (AlphaEvolve) |
+| $1.77898884$ | [MI2026] | Entropy construction on a 13-point support. |
 
 
 ## Additional comments and links
@@ -40,5 +41,6 @@ $$ H(X-Y) \leq C_{3b} \max( H(X), H(Y), H(X+Y)).$$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [GR2019] Green, B.; Ruzsa, I. Z. On the arithmetic Kakeya conjecture of Katz and Tao. Periodica Mathematica Hungarica, Volume 78, Issue 1, pp 135–151 (2019). DOI: 10.1007/s10958-018-2003-3.
 - [L2015] Lemm, Marius. New counterexamples for sums-differences. Proceedings of the American Mathematical Society, Vol. 143, No. 9 (SEPTEMBER 2015), pp. 3863-3868 (6 pages). DOI: 10.1090/proc/12731.
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 13-point entropy certificate for $C_{3b}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/NNN) (2026).
 - [KT1999] Katz, Nets Hawk; Tao, Terence. Bounds on arithmetic projections, and applications to the Kakeya conjecture. Math. Res. Lett. 6 (1999), no. 5-6, 625-630. DOI: 10.4310/MRL.1999.v6.n6.a3.
 - [KT2002] Katz, N. H.; Tao, T. New bounds for Kakeya problems. J. Anal. Math. 87 (2002), 231–263. DOI: 10.1007/BF02792310.

--- a/constants/3b.md
+++ b/constants/3b.md
@@ -41,6 +41,6 @@ $$ H(X-Y) \leq C_{3b} \max( H(X), H(Y), H(X+Y)).$$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [GR2019] Green, B.; Ruzsa, I. Z. On the arithmetic Kakeya conjecture of Katz and Tao. Periodica Mathematica Hungarica, Volume 78, Issue 1, pp 135–151 (2019). DOI: 10.1007/s10958-018-2003-3.
 - [L2015] Lemm, Marius. New counterexamples for sums-differences. Proceedings of the American Mathematical Society, Vol. 143, No. 9 (SEPTEMBER 2015), pp. 3863-3868 (6 pages). DOI: 10.1090/proc/12731.
-- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 13-point entropy certificate for $C_{3b}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/NNN) (2026).
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 13-point entropy certificate for $C_{3b}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/92) (2026).
 - [KT1999] Katz, Nets Hawk; Tao, Terence. Bounds on arithmetic projections, and applications to the Kakeya conjecture. Math. Res. Lett. 6 (1999), no. 5-6, 625-630. DOI: 10.4310/MRL.1999.v6.n6.a3.
 - [KT2002] Katz, N. H.; Tao, T. New bounds for Kakeya problems. J. Anal. Math. 87 (2002), 231–263. DOI: 10.1007/BF02792310.


### PR DESCRIPTION
## Summary

This updates the best known lower bound for the Kakeya-type sum-difference constant from

$$C_{3b} > 1.77898$$

([GGSWT2025], which improved [L2015] in the eighth decimal place) to

$$C_{3b} \geq 1.77898884,$$

an improvement in the sixth decimal place (certified margin $8.84 \times 10^{-6}$ over $1.77898$).

The bound comes from a 13-point entropy construction, using the entropy formulation already quoted on the `3b.md` page: for the pair $(X,Y)$ given below,

$$\frac{H(X-Y)}{\max(H(X),\,H(Y),\,H(X+Y))} \geq 1.77898884.$$

The exact rational weights (common denominator $10^{36}$, reduced) sum to exactly $1$, and the support is symmetric under $(x,y) \mapsto (y,x)$. The certified value is $1.778988841420693549\ldots$, safely below the proven upper bound $11/6 = 1.8333\ldots$ [KT1999].

## Certificate

| X | Y | exact weight |
|---:|---:|---:|
| -2 | 3 | 97361833892100293951 / 1000000000000000000000000000000000000 |
| -2 | 4 | 703 / 500000000000000000000000000000000000 |
| -1 | 2 | 24965915823534617097953539540121 / 100000000000000000000000000000000000 |
| -1 | 3 | 1371805003106379032651546041 / 62500000000000000000000000000000000 |
| 0 | 1 | 112120167204589061011718189111031549 / 500000000000000000000000000000000000 |
| 0 | 2 | 5630590219641637490184434793744907 / 200000000000000000000000000000000000 |
| 1 | 0 | 112120167204589061011718189111031549 / 500000000000000000000000000000000000 |
| 1 | 1 | 30919629173187274661345437236097393 / 62500000000000000000000000000000000 |
| 2 | -1 | 24965915823534617097953539540121 / 100000000000000000000000000000000000 |
| 2 | 0 | 5630590219641637490184434793744907 / 200000000000000000000000000000000000 |
| 3 | -2 | 97361833892100293951 / 1000000000000000000000000000000000000 |
| 3 | -1 | 1371805003106379032651546041 / 62500000000000000000000000000000000 |
| 4 | -2 | 703 / 500000000000000000000000000000000000 |

## Verification

All four linear forms ($X-Y$, $X$, $Y$, $X+Y$) take small integer values on the support,
so the pushforward distributions are computed exactly as rationals; the only inexact step
is the logarithm, which is enclosed with `mpmath` interval arithmetic. The reported bound
is the lower endpoint of the interval ratio, hence a rigorous lower bound on $C_{3b}$.

```python
#!/usr/bin/env python3
"""Replayable certificate check for the C_3b lower bound 1.77898884.

Exact rational pushforwards + mpmath interval arithmetic (dps=80).
The printed lower endpoint rho_lo is a rigorous lower bound on C_3b.
"""
from collections import defaultdict
from fractions import Fraction
import mpmath

# 13-point support; exact rational weights (sum is exactly 1).
WEIGHTS = [
    (-2,  3, Fraction(97361833892100293951, 1000000000000000000000000000000000000)),
    (-2,  4, Fraction(703, 500000000000000000000000000000000000)),
    (-1,  2, Fraction(24965915823534617097953539540121, 100000000000000000000000000000000000)),
    (-1,  3, Fraction(1371805003106379032651546041, 62500000000000000000000000000000000)),
    ( 0,  1, Fraction(112120167204589061011718189111031549, 500000000000000000000000000000000000)),
    ( 0,  2, Fraction(5630590219641637490184434793744907, 200000000000000000000000000000000000)),
    ( 1,  0, Fraction(112120167204589061011718189111031549, 500000000000000000000000000000000000)),
    ( 1,  1, Fraction(30919629173187274661345437236097393, 62500000000000000000000000000000000)),
    ( 2, -1, Fraction(24965915823534617097953539540121, 100000000000000000000000000000000000)),
    ( 2,  0, Fraction(5630590219641637490184434793744907, 200000000000000000000000000000000000)),
    ( 3, -2, Fraction(97361833892100293951, 1000000000000000000000000000000000000)),
    ( 3, -1, Fraction(1371805003106379032651546041, 62500000000000000000000000000000000)),
    ( 4, -2, Fraction(703, 500000000000000000000000000000000000)),
]
assert sum(w for _, _, w in WEIGHTS) == 1

mpmath.iv.dps = 80
mpmath.mp.dps = 80   # so interval endpoints are extracted exactly, with no re-rounding
iv = mpmath.iv

def H_interval(a, b):
    """Interval enclosure of H(a*X + b*Y) in nats."""
    dist = defaultdict(Fraction)
    for x, y, w in WEIGHTS:
        dist[a * x + b * y] += w
    H = iv.mpf(0)
    for q in dist.values():
        if q:
            qi = iv.mpf(q.numerator) / iv.mpf(q.denominator)
            H += qi * (-iv.log(qi))
    return H

N = H_interval(1, -1)                                  # H(X-Y)
slopes = [H_interval(1, 0), H_interval(0, 1), H_interval(1, 1)]
D_hi = max(mpmath.mpf(h.b) for h in slopes)            # upper bound on max slope entropy
rho = N / iv.mpf(D_hi)                                 # interval ratio
rho_lo = mpmath.mpf(rho.a)                             # rigorous lower bound on C_3b

print("H(X-Y) in", mpmath.nstr(N, 30))
print("max slope entropy <=", mpmath.nstr(D_hi, 30))
print("rho_lo =", mpmath.nstr(rho_lo, 12), "(true value 1.778988841420693549..., displayed digits truncated-safe)")
assert rho_lo > mpmath.mpf("1.77898884")
assert rho_lo > mpmath.mpf("1.778981")   # beats any eighth-decimal improvement of 1.77898
assert mpmath.mpf(rho.b) < mpmath.mpf(11) / 6   # sanity: below proven upper bound 11/6
print("OK: C_3b >= 1.77898884 certified")
```

Expected output:

```text
H(X-Y) in [1.223823395883792401230642456658973579453022111493986552795120117962458723325333444357, 1.223823395883792401230642456658973579453022111493986552795120117962458723325333465442]
max slope entropy <= 0.687932024861073221126046776533
rho_lo = 1.77898884142 (true value 1.778988841420693549..., displayed digits truncated-safe)
OK: C_3b >= 1.77898884 certified
```

The certificate was checked twice with independent code paths:

1. Our project verifier (mpmath interval certification, same architecture as the script
   above), re-run at dps=120 against the exact rational distribution.
2. A from-scratch independent re-check written without access to the original verifier,
   using only the Python standard library (`json`, `fractions`) plus `mpmath.iv` interval
   arithmetic at dps=100: pushforwards grouped as exact `Fraction`s, interval endpoints
   pulled back to exact dyadic rationals (via `libmp.to_rational`), and all verdicts
   decided by exact rational comparisons. It certifies
   $$\rho \in [1.778988841420693549805193887477,\ 1.778988841420693549805193887478]$$
   (interval width $4.3 \times 10^{-100}$).

## AI assistance disclosure

This is a fully AI-derived result: the construction was found and certified by Mosaic Intelligence's automated search-and-verification system, and the submission text was AI-prepared. All numerical results and references were independently re-run and verified before submission.
