### PR TITLE
Improve problem 3a lower bound to 1.1835129324... (exact-count certificate)

### DIFF
--- a/constants/3a.md
+++ b/constants/3a.md
@@ -23,6 +23,7 @@ $$ |A-B| \gg |A+B|^{C_{3a}}.$$
 | $1.173050$ |[G2025] |
 | $1.173077$ |[Z2025]|
 | $1.1740744$ | [G2026] | Base-$21$ digit construction with exact counting certificate. |
+| $1.1823357212$ | [MI2026] | Base-$33$ digit construction with exact counting certificate. |
 
 
 ## Additional comments and links
@@ -36,5 +37,6 @@ $C_{3a} \geq 1 + \log( \lvert U-U \rvert /\lvert U+U \rvert )/\log(2 \max(U)+1)$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [G2025] Gerbicz, Robert. Sums and differences of sets (improvement over AlphaEvolve), 2025. [arXiv:2505.16105](https://arxiv.org/abs/2505.16105).
 - [GHR2007] Gyarmati, Katalin; Hennecart, François; Ruzsa, Imre Z. Sums and differences of finite sets. Functiones et Approximatio Commentarii Mathematici, 37(1):175–186, 2007.
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). Exact-count certificate for problem 3a, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/NNN) (2026).
 - [Z2025] Zheng, Fan. Sums and differences of sets: a further improvement over AlphaEvolve, 2025. [arXiv:2506.01896](https://arxiv.org/abs/2506.01896).
 - [G2026] Griego, Sebastian. Base-$21$ digit construction certificate for $C_{3a}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/71) (2026).

--- a/constants/3a.md
+++ b/constants/3a.md
@@ -37,6 +37,6 @@ $C_{3a} \geq 1 + \log( \lvert U-U \rvert /\lvert U+U \rvert )/\log(2 \max(U)+1)$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [G2025] Gerbicz, Robert. Sums and differences of sets (improvement over AlphaEvolve), 2025. [arXiv:2505.16105](https://arxiv.org/abs/2505.16105).
 - [GHR2007] Gyarmati, Katalin; Hennecart, François; Ruzsa, Imre Z. Sums and differences of finite sets. Functiones et Approximatio Commentarii Mathematici, 37(1):175–186, 2007.
-- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). Exact-count certificate for problem 3a, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/NNN) (2026).
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). Exact-count certificate for problem 3a, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/95) (2026).
 - [Z2025] Zheng, Fan. Sums and differences of sets: a further improvement over AlphaEvolve, 2025. [arXiv:2506.01896](https://arxiv.org/abs/2506.01896).
 - [G2026] Griego, Sebastian. Base-$21$ digit construction certificate for $C_{3a}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/71) (2026).

--- a/constants/3a.md
+++ b/constants/3a.md
@@ -23,7 +23,7 @@ $$ |A-B| \gg |A+B|^{C_{3a}}.$$
 | $1.173050$ |[G2025] |
 | $1.173077$ |[Z2025]|
 | $1.1740744$ | [G2026] | Base-$21$ digit construction with exact counting certificate. |
-| $1.1830053419$ | [MI2026] | Base-$33$ digit construction with exact counting certificate. |
+| $1.1835129324$ | [MI2026] | Base-$33$ digit construction with exact counting certificate. |
 
 
 ## Additional comments and links

--- a/constants/3a.md
+++ b/constants/3a.md
@@ -23,7 +23,7 @@ $$ |A-B| \gg |A+B|^{C_{3a}}.$$
 | $1.173050$ |[G2025] |
 | $1.173077$ |[Z2025]|
 | $1.1740744$ | [G2026] | Base-$21$ digit construction with exact counting certificate. |
-| $1.1823357212$ | [MI2026] | Base-$33$ digit construction with exact counting certificate. |
+| $1.1830053419$ | [MI2026] | Base-$33$ digit construction with exact counting certificate. |
 
 
 ## Additional comments and links


### PR DESCRIPTION
### Result

This PR improves the lower bound for problem 3a (the Gyarmati–Hennecart–Ruzsa
sum-difference constant) to:

```
C_3a >= 1.1835129324218615106564747894020784326947   (40 digits, floor-truncated)
```

(100-digit floor-truncated string available in the certificate artifact.
Every quoted string is a valid lower bound; no nearest rounding anywhere.)

Margin over the published record (1.1740744, [G2026]):
**+0.0094385324218615106564747894020784326947** (exact, the record value being
exactly rational) — for scale, the published 2025→2026 progression advanced
+0.001.

### Construction

Same capped digit-family construction as [G2026], at stronger parameters:

- Digit alphabet A = {0, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
  base B = 33, depth d = 420, cap T = 1392.
- U is the set of all integers whose base-33 expansion uses 420 digits from A
  with digit sum at most T; the GHR lemma bound is
  1 + log(|U−U|/|U+U|)/log(2 max(U)+1).
- The three certificate integers (|U+U|, |U−U|, max(U)) are computed by exact
  dynamic programming (no floats anywhere); the full integers are in the
  attached artifact `gh3a_b33_d420_T1392_counts.json`
  ([gist](https://gist.github.com/463464q435q43/0d43127ed3c8055c9cafa02d8c2cec51)).
- Why this works: the [G2026] record point (d = 80 in a base-21 alphabet)
  sits ~0.0085 below its own family's asymptote; the base-33 alphabet above
  has asymptote V∞ = 1.1855230 (cap ratio τ* = 3.29707), and larger d climbs
  toward it (here τ = 1392/420 = 3.31429).

A second, fully independently audited rung of the same family is included as
a smaller exhibit for the reviewer: d = 120, T = 384, certifying
`C_3a >= 1.1795410574186522379964980688629718533566`
(artifact `gh3a_b33_d120_T384_counts.json` in the same gist; its serial
recount takes ~1h vs. days for d = 420). It is strictly superseded by
the headline. (The d = 240 and d = 320 rungs that headlined earlier revisions
of this PR, `C_3a >= 1.1823357212262927829173650427903744879117` and
`C_3a >= 1.1830053419750735511771153534053862079772`, remain in the gist with
their own verification artifacts; both are strictly superseded.)

### Verification

All counting is exact integer DP; the value is certified as an exact-rational
log enclosure (quoted digits are floor truncations). Each of the three
integers was recomputed by independently written implementations:

- max(U): greedy top-down construction == budget-DP recount (different
  algorithm), and independently reproduced digit-for-digit by the audit-side
  recount below.
- |U−U|: three implementations agree digit-for-digit — dict DP over digit-sum
  pairs; a CRT/modular DP with exact reconstruction (different arithmetic);
  and an independent dual disjoint 57-bit prime-set CRT lattice DP
  (different author, different code, different arithmetic; 38 primes per set,
  the two disjoint prime sets reconstructing the same integer).
- |U+U|: chunk-parallel bitset DP, recounted digit-for-digit (474 digits) by
  a second, independently written parallel implementation. In addition, the
  independent CRT layer certifies a proven upper bound S_relax >= |U+U| with
  relative gap 2.8e-190; the rigorous lower bound computed from S_relax alone
  (audit code only, no producer numbers) already reproduces all 40 headline
  digits.
- Independent recount verdict artifact: `crt_verify_d420.json` (same gist) —
  PASS on all checks, beats the record and the d = 120 rung in exact rational
  arithmetic.
- Bonus zero-transcendental check: the pure-integer inequality
  `|U−U|^11 > |U+U|^11 * (2 max(U)+1)^2` independently establishes
  C_3a > 1 + 2/11 = 1.1818... > 1.1740744 with a single big-integer
  comparison (no logs needed).
- Admissibility re-derived from the problem page (B = 2 max(A)+1 = 33, so the
  no-carry boundary holds exactly and the DP counts are exact).

Replay (standalone checker `independent_check_3a.py` in the gist; stdlib
only, from-scratch implementations, two |U−U| algorithms cross-checked
internally):

```
python3 independent_check_3a.py verify \
  '{"digit_set": [0,3,4,6,7,8,9,10,11,12,13,14,15,16], "base": 33, "digit_count": 420, "sum_cap": 1392}' \
  --claimed gh3a_b33_d420_T1392_counts.json --power-check 2/11
# expected: all three counts match the artifact digit-for-digit, exit 0
# (serial recount at d=420 is days-scale; the d=120 exhibit replays in ~1h:
#  same command with "digit_count": 120, "sum_cap": 384 and the d120 artifact)
```

`python3 independent_check_3a.py selftest` checks every counter against
brute-force enumeration on small instances (seconds).

### Attribution

Construction family due to [G2026] (the current record holder's method,
optimized within and beyond its published parameters). New-content tag:
`[MI2026]`, Mosaic Intelligence ([@111111](https://x.com/111111)) — same
attribution as our submissions #92/#93.

### AI assistance disclosure

This is a fully AI-derived result: the construction was found and certified by
Mosaic Intelligence's automated search-and-verification system, and the
submission text was AI-prepared. All numerical results and references were
independently re-run and verified before submission.
