### PR TITLE
fix: escape inline LaTeX subscript on cap set constant page

### DIFF
--- a/constants/4a.md
+++ b/constants/4a.md
@@ -25,7 +25,7 @@ Let $r(n)$ be the size of the largest cap set in $\mathbb{F}\_{3}^{n}$, i.e., a 
 
 ## Additional comments and links
 
-- Any cap set $A$ in $\mathbb F_{3}^n$ gives a lower bound $C_{4} \geq \lvert A\rvert^{1/n}$ by taking Cartesian powers.  For similar reason, the limit $\lim_{n \to \infty} r(n)^{1/n}$ exists and equals $C_{4}$.
+- Any cap set $A$ in $\mathbb F\_{3}^n$ gives a lower bound $C_{4} \geq \lvert A\rvert^{1/n}$ by taking Cartesian powers.  For similar reason, the limit $\lim_{n \to \infty} r(n)^{1/n}$ exists and equals $C_{4}$.
 - [Wikipedia page on cap sets](https://en.wikipedia.org/wiki/Cap_set)
 - Also connected to the sunflower conjecture; see [NS2016].
 


### PR DESCRIPTION
## Summary
Fixes broken inline math rendering on the C₄ constant page.

## Bug
On the cap set constant page, `$\mathbb F_{3}^n$` in inline math is parsed by Kramdown as emphasis markup, breaking the LaTeX (see #8).

## Root cause
Underscores in inline `$...$` math are interpreted as Markdown emphasis unless escaped.

## Why this fix is correct
The same page already uses the escaped form `$\mathbb{F}\_{3}^{n}$` in the definition section; this applies the project convention from CONTRIBUTING.md to the remaining occurrence in Additional comments.

Fixes #8

## Test plan
- [ ] Verify `constants/4a.html` renders `F_3^n` correctly on GitHub Pages

Made with [Cursor](https://cursor.com)