### PR TITLE
fix: escape inline LaTeX subscripts on Shannon capacity page

### DIFF
--- a/constants/9a.md
+++ b/constants/9a.md
@@ -3,10 +3,10 @@
 ## Description of constant
 
 Let $\mathcal{C}\_{7}$ denote the cycle graph on $7$ vertices.
-We define $C_{9}$ to be the **Shannon capacity** of ${\mathcal C}_{7}$:
+We define $C_{9}$ to be the **Shannon capacity** of ${\mathcal C}\_{7}$:
 
 $$
-C_{9} := \Theta({\mathcal C}_{7}),
+C_{9} := \Theta({\mathcal C}\_{7}),
 $$
 
 where for a graph $G$, the Shannon capacity $\Theta(G)$ is defined by


### PR DESCRIPTION
## Summary
Escapes `\_{7}` in two inline formulas on the Shannon capacity constant page.

## Bug
Issue #8 reports that Kramdown treats paired underscores as emphasis and breaks inline MathJax. On `constants/9.html`, lines like `$C_{9} := \Theta({\mathcal C}_{7})$` put two subscripts on one line, garbling the rendered LaTeX.

## Root cause
Unescaped `_` inside inline math is parsed as Markdown emphasis before MathJax runs.

## Why this fix is correct
Same `\_{…}` escaping already used on this page and in #96 for the cap set page; teorth confirmed that pattern fixes the rendering.

Fixes remaining breakage on https://teorth.github.io/optimizationproblems/constants/9.html from #8.

## Test plan
- [ ] Rebuild the site and confirm `constants/9.html` renders `$C_{9} := \Theta(\mathcal C_{7})$` correctly

Made with [Cursor](https://cursor.com)