### PR TITLE
fix: escape inline LaTeX subscripts on Marton constant page

### DIFF
--- a/constants/18a.md
+++ b/constants/18a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{18}$ is the least constant such that, whenever $A$ is a subset of $\mathbb F_{2}^n$ with $\lvert A+A\rvert \leq K\lvert A\rvert$, then $A$ can be covered by $K^{C_{18}+o(1)}$ cosets of a subspace of cardinality at most $\lvert A\rvert$, where the limit $o(1)$ is with respect to the limit $K \to \infty$.
+$C_{18}$ is the least constant such that, whenever $A$ is a subset of $\mathbb F\_{2}^n$ with $\lvert A+A\rvert \leq K\lvert A\rvert$, then $A$ can be covered by $K^{C_{18}+o(1)}$ cosets of a subspace of cardinality at most $\lvert A\rvert$, where the limit $o(1)$ is with respect to the limit $K \to \infty$.
 
 ## Known upper bounds
 
@@ -19,7 +19,7 @@ $C_{18}$ is the least constant such that, whenever $A$ is a subset of $\mathbb F
 
 ## Additional comments and links
 
-- Conjectured to be finite by Katalin Marton, as recorded in [R1999].  It is the special case of the Polynomial Freiman-Ruzsa (PFR) conjecture when the ambient group is a vector space over the field $\mathbb F_{2}$.  (The precise formulation of the PFR conjecture in the case of unbounded torsion is still not fully settled.)
+- Conjectured to be finite by Katalin Marton, as recorded in [R1999].  It is the special case of the Polynomial Freiman-Ruzsa (PFR) conjecture when the ambient group is a vector space over the field $\mathbb F\_{2}$.  (The precise formulation of the PFR conjecture in the case of unbounded torsion is still not fully settled.)
 - The lower bound of 1 is not expected to be sharp.
 - Surveys on this problem can be found at [G2005], [G-unpub], and [Lovett2015].
 
@@ -29,5 +29,5 @@ $C_{18}$ is the least constant such that, whenever $A$ is a subset of $\mathbb F
 - [G-unpub] Green, B. J. *Notes on the polynomial Freiman–Ruzsa conjecture.* Unpublished note available at https://people.maths.ox.ac.uk/greenbj/papers/PFR.pdf
 - [GGMT2025] Gowers, W. T.; Green, B.; Manners, F.; Tao, T. *On a conjecture of Marton.* Annals of Mathematics, Second Series, Volume 201 (2025), Issue 2, 515–549. [arXiv:2311.05762](https://arxiv.org/abs/2311.05762)
 - [Lovett2015] Lovett, S. *An Exposition of Sanders’ Quasi-Polynomial Freiman–Ruzsa Theorem.* Theory of Computing Library Graduate Surveys 6 (2015), 1–14.
-- [L2024] Liao, J.-J. *Improved Exponent for Marton's Conjecture in $\mathbb F_{2}^n$.* [arXiv:2404.09639](https://arxiv.org/abs/2404.09639) (2024).
+- [L2024] Liao, J.-J. *Improved Exponent for Marton's Conjecture in $\mathbb F\_{2}^n$.* [arXiv:2404.09639](https://arxiv.org/abs/2404.09639) (2024).
 - [R1999] Ruzsa, I. Z. *An analog of Freiman’s theorem in groups.* Astérisque 258 (1999), 323–326.


### PR DESCRIPTION
## Summary
Escapes inline `_` subscripts in `constants/18a.md` so Jekyll/Kramdown no longer treats `F_{2}` as emphasis markup.

## Bug
Issue #8 reported that `constants/18.html` breaks because paired underscores inside inline math are parsed as Markdown emphasis.

## Root cause
`$\mathbb F_{2}^n$` and `$\mathbb F_{2}$` contain unescaped `_` characters outside LaTeX math mode parsing on the static site.

## Why this fix is correct
Matches the workaround confirmed in #8 (`\_` before `_`) and the fixes already merged for the cap set and Shannon capacity pages.

## Test plan
- [ ] `constants/18.html` renders `𝔽₂` correctly on the GitHub Pages site


Made with [Cursor](https://cursor.com)