### PR TITLE
fix: escape remaining inline subscripts on Shannon capacity page

### DIFF
--- a/constants/9a.md
+++ b/constants/9a.md
@@ -25,7 +25,7 @@ is the strong graph product.
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 | $7/2 = 3.5$ | [S1956] | Fractional clique cover bound |
-| $\vartheta({\mathcal C}_{7}) \approx 3.3177$ | [L1979] | Lovász theta-function bound |
+| $\vartheta({\mathcal C}\_{7}) \approx 3.3177$ | [L1979] | Lovász theta-function bound |
 
 ---
 
@@ -46,7 +46,7 @@ is the strong graph product.
 channel whose confusability graph is $G$.
 - Determining $\Theta({\mathcal C}_{2k+1})$ for odd cycles is a central open problem in information theory and extremal combinatorics.
 - For ${\mathcal C}\_{5}$, Lovász famously proved $\Theta({\mathcal C}\_{5})=\sqrt{5}$, but no exact value is
-  known for $\Theta({\mathcal C}_{7})$.
+  known for $\Theta({\mathcal C}\_{7})$.
 - It is possible that $\Theta({\mathcal C}\_{2k+1})=\vartheta({\mathcal C}\_{2k+1})$ for all $k$,
   but this is currently open beyond $k=2$.
 
@@ -57,10 +57,10 @@ channel whose confusability graph is $G$.
 problem. Computers in Algebra and Number Theory, American Mathematical Society, Providence,
 RI (1971), 97–108.
 - [L1979] Lovász, L. On the Shannon capacity of a graph. IEEE Transactions on Information Theory **25** (1979), 1–7.
-- [PS2018] Sven Polak, Alexander Schrijver. New lower bound on the Shannon capacity of $C_7$ from circular graphs. Information Processing Letters, 143 (2019), 37-40. arXiv:1808.07438.
+- [PS2018] Sven Polak, Alexander Schrijver. New lower bound on the Shannon capacity of $C\_7$ from circular graphs. Information Processing Letters, 143 (2019), 37-40. arXiv:1808.07438.
 - [MO2017] K.A. Mathew, P.R.J. Östergård. New lower bounds for the Shannon capacity of odd cycles. Designs,
 Codes and Cryptography, 84 (2017), 13–22.
-- [VZ2002] A. Vesel, J. Zerovnik. Improved lower bound on the Shannon capacity of $C_7$. Information Processing
+- [VZ2002] A. Vesel, J. Zerovnik. Improved lower bound on the Shannon capacity of $C\_7$. Information Processing
 Letters, 81 (2002), 277–282.
 
 ## Contribution notes


### PR DESCRIPTION
## Summary
Kramdown treats `_` as emphasis outside math mode, so unescaped subscripts in inline `$...$` on constants/9 were broken after #97.

## Root cause
Four occurrences of `C_7` / `{\mathcal C}_7` in the table, comments, and references were still unescaped.

## Fix
Escape the subscripts with `\_` so the rendered page shows the intended 7-cycle notation.

Made with [Cursor](https://cursor.com)