### PR TITLE
fix: escape inline subscripts on cap set and zero-free region pages

### DIFF
--- a/constants/4a.md
+++ b/constants/4a.md
@@ -33,7 +33,7 @@ Let $r(n)$ be the size of the largest cap set in $\mathbb{F}\_{3}^{n}$, i.e., a 
 
 - [CF1994] Calderbank, A. Robert; Fishburn, Peter C. Maximal three-independent subsets of $\\{0,1,2\\}^n$. Des. Codes Cryptogr. 4, No. 3, 203-211 (1994).
 - [E2004] Edel, Y. New lower bounds for caps in $AG(4, 3)$. Des. Codes Cryptogr. 33, No. 1-3, 149-160 (2004).
-- [EG2016] Ellenberg, Jordan S.; Gijswijt, Dion. On large subsets of $F^n_q$ with no three-term arithmetic progression. Ann. of Math. (2) 185 (2017), no. 1, 339–343. [arXiv:1605.09223](https://arxiv.org/abs/1605.09223)
+- [EG2016] Ellenberg, Jordan S.; Gijswijt, Dion. On large subsets of $F^n\_q$ with no three-term arithmetic progression. Ann. of Math. (2) 185 (2017), no. 1, 339–343. [arXiv:1605.09223](https://arxiv.org/abs/1605.09223)
 - [NS2016] Naslund, Eric; Sawin, William F. Upper bounds for sunflower-free sets. [arXiv:1606.09575](https://arxiv.org/abs/1606.09575)
 - [P1970] Pellegrino, Giuseppe. Sul massimo ordine delle calotte in $S_{4,3}$. Matematiche (Catania) 25 (1970), no. 10, 1–9.
 - [RBNBKDREWFKF2023] Romera-Paredes, Bernardino; Barekatain, Mohammadamin; Novikov, Alexander; Balog, Matej; Kumar, M. Pawan; Dupont, Emilien; Ruiz, Francisco J. R.; Ellenberg, Jordan S.; Wang, Pengming; Fawzi, Omar; Kohli, Pushmeet; Fawzi, Alhussein. Mathematical discoveries from program search with large language models. Nature. 625 (7995): 468–475 (2023).

--- a/constants/8a.md
+++ b/constants/8a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{8} = R$ is the least constant such that there are no zeroes $\sigma+it$ of the Riemann zeta function with $\lvert t \rvert \geq 2$ and $\sigma > 1 - \frac{1}{R \log \lvert t \rvert}$.
+$C\_{8} = R$ is the least constant such that there are no zeroes $\sigma+it$ of the Riemann zeta function with $\lvert t \rvert \geq 2$ and $\sigma > 1 - \frac{1}{R \log \lvert t \rvert}$.
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
Issue #8: Kramdown breaks inline LaTeX when `_` is not escaped inside `$...$`.

## Root cause
`$F^n_q$` in the [EG2016] reference on constants/4 and `$C_{8}$` in the constants/8 definition were still unescaped after #96.

## Fix
Use `\_` so the cap-set field notation and zero-free region constant render correctly.

Made with [Cursor](https://cursor.com)