### PR TITLE
Update constant 45a

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [42](https://teorth.github.io/optimizationproblems/constants/42a.html) | Turan's pure power sum constant | 0.5 | 0.69368 |
 | [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.8559 | 0.86602540378 |
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |
-| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | <0.49024898035099 |
+| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | <0.490248930138966 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
 | [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 4 |
 | [48](https://teorth.github.io/optimizationproblems/constants/48a.html) | One-dimensional convex sub-Gaussian comparison constant | $\approx 5.33386$ | $\approx 5.33386$ |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [42](https://teorth.github.io/optimizationproblems/constants/42a.html) | Turan's pure power sum constant | 0.5 | 0.69368 |
 | [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.8559 | 0.86602540378 |
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |
-| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490341088858244 |
+| [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | <0.49024898035099 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
 | [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 4 |
 | [48](https://teorth.github.io/optimizationproblems/constants/48a.html) | One-dimensional convex sub-Gaussian comparison constant | $\approx 5.33386$ | $\approx 5.33386$ |

--- a/constants/45a.md
+++ b/constants/45a.md
@@ -4,12 +4,6 @@
 
 $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers that can be expressed as the sum of a prime number and a power of two.
 
-Writing $A$ for this set, an explicit finite obstruction computation gives the upper-density bound
-$$
-\overline d(A)<0.490249407811155.
-$$
-[G2026-ub-0-490249407811155] If the density exists, this gives the corresponding upper bound for $C_{45}$.
-
 ## Known upper bounds
 
 | Bound | Reference | Comments |
@@ -89,7 +83,7 @@ The external verifier independently recomputes the 13-prime seed histogram from 
 
 - [G2026] Griego, Sebastian. 36-prime obstruction certificate for Romanoff's constant upper-density bound, 2026. [Code and verification](https://github.com/sebastian-griego/c45-romanoff-certificate/tree/v1-c45-certificate).
 - [G2026-ub-0-490249407811155] **loc:** external verifier repository, `verify_all.sh`. **quote:** "The exact rational verifier proves the upper-density bound \(\overline d(A)<0.490249407811155\)."
-- [Y2026] Yoo, Andrew, "An improved upper bound on Romanoff's constant," 2026. https://github.com/andrew-yoo/romanoff.
+- [Y2026] Yoo, Andrew, "An improved upper bound on Romanoff's constant," 2026. https://github.com/andrew-yoo/romanoff/tree/v1.
 
 
 ## Contribution notes

--- a/constants/45a.md
+++ b/constants/45a.md
@@ -13,7 +13,7 @@ $C_{45}$ is the asymptotic density (if it exists) of the set of odd integers tha
 | $0.490941$ | [HR2006] | |
 | $0.490341088858244$ | [CDL2024] | |
 | $<0.490249407811155$ | [G2026] | 36-prime finite obstruction certificate with exact cluster-update verification. |
-| $<0.49024898035099$ | [Y2026] | |
+| $<0.490248930138966$ | [Y2026] | |
 
 ## Known lower bounds
 
@@ -83,7 +83,7 @@ The external verifier independently recomputes the 13-prime seed histogram from 
 
 - [G2026] Griego, Sebastian. 36-prime obstruction certificate for Romanoff's constant upper-density bound, 2026. [Code and verification](https://github.com/sebastian-griego/c45-romanoff-certificate/tree/v1-c45-certificate).
 - [G2026-ub-0-490249407811155] **loc:** external verifier repository, `verify_all.sh`. **quote:** "The exact rational verifier proves the upper-density bound \(\overline d(A)<0.490249407811155\)."
-- [Y2026] Yoo, Andrew, "An improved upper bound on Romanoff's constant," 2026. https://github.com/andrew-yoo/romanoff/tree/v1.
+- [Y2026] Yoo, Andrew, "An improved upper bound on Romanoff's constant," 2026. https://github.com/andrew-yoo/romanoff/tree/v2.
 
 
 ## Contribution notes

--- a/constants/45a.md
+++ b/constants/45a.md
@@ -19,13 +19,14 @@ $$
 | $0.490941$ | [HR2006] | |
 | $0.490341088858244$ | [CDL2024] | |
 | $<0.490249407811155$ | [G2026] | 36-prime finite obstruction certificate with exact cluster-update verification. |
+| $<0.49024898035099$ | [Y2026] | |
 
 ## Known lower bounds
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| 0 | Trivial | |
-| >0 | [R1934] | |
+| $0$ | Trivial | |
+| $>0$ | [R1934] | |
 | $0.0868$ | [CS2004] |  |
 | $0.0936$ | [P2006] | |
 | $0.093627$ | [HS2010] | |
@@ -88,6 +89,7 @@ The external verifier independently recomputes the 13-prime seed histogram from 
 
 - [G2026] Griego, Sebastian. 36-prime obstruction certificate for Romanoff's constant upper-density bound, 2026. [Code and verification](https://github.com/sebastian-griego/c45-romanoff-certificate/tree/v1-c45-certificate).
 - [G2026-ub-0-490249407811155] **loc:** external verifier repository, `verify_all.sh`. **quote:** "The exact rational verifier proves the upper-density bound \(\overline d(A)<0.490249407811155\)."
+- [Y2026] Yoo, Andrew, "An improved upper bound on Romanoff's constant," 2026. https://github.com/andrew-yoo/romanoff.
 
 
 ## Contribution notes


### PR DESCRIPTION
This improves the upper bound for Romanoff's constant by optimizing the prime set.

(Disclosure: I am the author.)