### PR TITLE
Add stable archive links for MI2026 certificates

### DIFF
--- a/constants/3a.md
+++ b/constants/3a.md
@@ -37,6 +37,6 @@ $C_{3a} \geq 1 + \log( \lvert U-U \rvert /\lvert U+U \rvert )/\log(2 \max(U)+1)$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [G2025] Gerbicz, Robert. Sums and differences of sets (improvement over AlphaEvolve), 2025. [arXiv:2505.16105](https://arxiv.org/abs/2505.16105).
 - [GHR2007] Gyarmati, Katalin; Hennecart, François; Ruzsa, Imre Z. Sums and differences of finite sets. Functiones et Approximatio Commentarii Mathematici, 37(1):175–186, 2007.
-- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). Exact-count certificate for problem 3a, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/95) (2026).
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). Exact-count certificate for problem 3a, [certificate archive](https://doi.org/10.5281/zenodo.20794135), [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/95) (2026).
 - [Z2025] Zheng, Fan. Sums and differences of sets: a further improvement over AlphaEvolve, 2025. [arXiv:2506.01896](https://arxiv.org/abs/2506.01896).
 - [G2026] Griego, Sebastian. Base-$21$ digit construction certificate for $C_{3a}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/71) (2026).

--- a/constants/3b.md
+++ b/constants/3b.md
@@ -41,6 +41,6 @@ $$ H(X-Y) \leq C_{3b} \max( H(X), H(Y), H(X+Y)).$$
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [GR2019] Green, B.; Ruzsa, I. Z. On the arithmetic Kakeya conjecture of Katz and Tao. Periodica Mathematica Hungarica, Volume 78, Issue 1, pp 135–151 (2019). DOI: 10.1007/s10958-018-2003-3.
 - [L2015] Lemm, Marius. New counterexamples for sums-differences. Proceedings of the American Mathematical Society, Vol. 143, No. 9 (SEPTEMBER 2015), pp. 3863-3868 (6 pages). DOI: 10.1090/proc/12731.
-- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 13-point entropy certificate for $C_{3b}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/92) (2026).
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 13-point entropy certificate for $C_{3b}$, [certificate archive](https://doi.org/10.5281/zenodo.20794135), [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/92) (2026).
 - [KT1999] Katz, Nets Hawk; Tao, Terence. Bounds on arithmetic projections, and applications to the Kakeya conjecture. Math. Res. Lett. 6 (1999), no. 5-6, 625-630. DOI: 10.4310/MRL.1999.v6.n6.a3.
 - [KT2002] Katz, N. H.; Tao, T. New bounds for Kakeya problems. J. Anal. Math. 87 (2002), 231–263. DOI: 10.1007/BF02792310.

--- a/constants/3c.md
+++ b/constants/3c.md
@@ -51,7 +51,7 @@ $$ H(X-Y) \leq C_{3c} \max( H(X), H(Y), H(X+Y), H(X+2Y)).$$ This entropy formula
 - [GGSWT2025] Georgiev, Bogdan; Gómez-Serrano, Javier; Tao, Terence; Wagner, Adam Zsolt. Mathematical exploration and discovery at scale. [arXiv:2511.02864](https://arxiv.org/abs/2511.02864)
 - [GR2019] Green, B.; Ruzsa, I. Z. On the arithmetic Kakeya conjecture of Katz and Tao. Periodica Mathematica Hungarica, Volume 78, Issue 1, pp 135–151 (2019). DOI: 10.1007/s10958-018-2003-3.
 - [L2015] Lemm, Marius. New counterexamples for sums-differences. Proceedings of the American Mathematical Society, Vol. 143, No. 9 (SEPTEMBER 2015), pp. 3863-3868 (6 pages). DOI: 10.1090/proc/12731.
-- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 95-point entropy certificate for $C_{3c}$, [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/93) (2026).
+- [MI2026] Mosaic Intelligence ([@111111](https://x.com/111111)). 95-point entropy certificate for $C_{3c}$, [certificate archive](https://doi.org/10.5281/zenodo.20794135), [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/93) (2026).
 - [KT1999] Katz, Nets Hawk; Tao, Terence. Bounds on arithmetic projections, and applications to the Kakeya conjecture. Math. Res. Lett. 6 (1999), no. 5-6, 625-630. DOI: 10.4310/MRL.1999.v6.n6.a3.
 - [KT2002] Katz, N. H.; Tao, T. New bounds for Kakeya problems. J. Anal. Math. 87 (2002), 231–263. DOI: 10.1007/BF02792310.
 

--- a/constants/71a.md
+++ b/constants/71a.md
@@ -98,9 +98,9 @@ $$
 	  **loc:** arXiv PDF p. 15, Theorem 4.4
 	  **quote:** "Any constant $C$ in Conjecture 1.1 satisfies $C\ge \beta(1/2)>6.4547837$, even when restricted to monotone functions."
 
-- <a id="MI2026"></a>**[MI2026]** Mosaic Intelligence ([@111111](https://x.com/111111)). *An improved lower bound for the Fourier Entropy-Influence constant from explicit balanced functions.* [Submitted to this repository](https://github.com/teorth/optimizationproblems/pull/94) (2026).
+- <a id="MI2026"></a>**[MI2026]** Mosaic Intelligence ([@111111](https://x.com/111111)). *An improved lower bound for the Fourier Entropy-Influence constant from explicit balanced functions.* [Certificate archive](https://doi.org/10.5281/zenodo.20794146), [submitted to this repository](https://github.com/teorth/optimizationproblems/pull/94) (2026).
 	- <a id="MI2026-bound"></a>**[MI2026-bound]**
-	  **loc:** this pull request
+	  **loc:** certificate archive and this pull request
 	  **quote:** "C_71 > 6.4901128435233943 — and, by the same logic-monotone certificate, even restricted to monotone functions (full floor-truncated value 6.49011284352339435967722960726821776674269968263998854502375); certified by the replayable script below."
 
 ## Contribution notes


### PR DESCRIPTION
## Summary

This follow-up adds stable Zenodo certificate-archive links to the four merged
MI2026 references, as invited in PR #94:

> If your institution (Mosaic Intelligence) has a more stable URL, please feel
> free to submit an additional PR providing that URL (or a github repository,
> etc.) for these contributions.

The new records are:

- Sum-difference certificates for `C_3a`, `C_3b`, and `C_3c`:
  https://doi.org/10.5281/zenodo.20794135
- Fourier Entropy-Influence certificate for `C_71`:
  https://doi.org/10.5281/zenodo.20794146

## Scope

Reference update only. No constants, bounds, certificates, or mathematical
claims are changed.

## Files

- `constants/3a.md`
- `constants/3b.md`
- `constants/3c.md`
- `constants/71a.md`

