### PR TITLE
fix: escape inline subscripts on real Grothendieck constant page

### DIFF
--- a/constants/10a.md
+++ b/constants/10a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{10}$ is the **real Grothendieck constant** $K_{G}^{\mathbb R}$.
+$C\_{10}$ is the **real Grothendieck constant** $K\_{G}^{\mathbb R}$.
 
 It is the smallest constant $C$ such that for every $m,n \ge 1$ and every real matrix
 


### PR DESCRIPTION
## Summary
- Unescaped `_` in the `$C_{10}$` / `$K_G$` definition on `constants/10a.md`.

## Root cause
Kramdown treats consecutive underscores as emphasis (#8). PR #11 fixed this on the old `constants/10.md`; the split into `10a.md` dropped the escaping, so the Grothendieck constant definition renders incorrectly on the site.

## Fix
Use `\_` in inline math, matching #96–#100.

## Test plan
- [ ] constants/10a.html shows `$C_{10}$` and `$K_G$` correctly


Made with [Cursor](https://cursor.com)