### PR TITLE
fix: escape inline subscripts on diagonal Ramsey constant page

### DIFF
--- a/constants/17a.md
+++ b/constants/17a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{17}$ is the limit (if it exists) of $R(k)^{1/k}$ as $k \to \infty$, where the diagonal Ramsey number $R(k)$ is the smallest integer $n$ such that every red/blue colouring of the edges of the complete graph $K_{n}$ contains a monochromatic copy of $K_{k}$.
+$C\_{17}$ is the limit (if it exists) of $R(k)^{1/k}$ as $k \to \infty$, where the diagonal Ramsey number $R(k)$ is the smallest integer $n$ such that every red/blue colouring of the edges of the complete graph $K\_{n}$ contains a monochromatic copy of $K\_{k}$.
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
- Unescaped `_` in `$C_{17}$`, `$K_n$`, and `$K_k$` on the definition line of `constants/17a.md`.

## Root cause
Same Kramdown emphasis bug as #8. PR #11 fixed `constants/17.md`; after the split to `17a.md` the subscripts were no longer escaped, breaking the Ramsey-number definition on the site.

## Fix
Use `\_` in inline math, matching #96–#100.

## Test plan
- [ ] constants/17a.html renders `$K_n$` and `$K_k$` correctly


Made with [Cursor](https://cursor.com)