### PR TITLE
fix: escape inline subscripts on matrix multiplication exponent page

### DIFF
--- a/constants/15a.md
+++ b/constants/15a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-We define $C_{15a}$ to be the matrix multiplication exponent $\omega$, the smallest real number such that two $n \times n$ matrices over a field can be multiplied using $O(n^{\omega + o(1)})$ arithmetic operations.
+We define $C\_{15a}$ to be the matrix multiplication exponent $\omega$, the smallest real number such that two $n \times n$ matrices over a field can be multiplied using $O(n^{\omega + o(1)})$ arithmetic operations.
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
Kramdown treats unescaped `_` inside inline `$...$` as emphasis, so `$C_{15a}$` on constants/15a was rendering incorrectly (see #8).

## Fix
Escape the subscript as `$C\_{15a}$`, matching the pattern in #96–#100 and CONTRIBUTING.md.


Made with [Cursor](https://cursor.com)