### PR TITLE
fix: escape inline subscripts on tight knot constant page

### DIFF
--- a/constants/22a.md
+++ b/constants/22a.md
@@ -2,9 +2,9 @@
 
 ## Description of constant
 
-$C_{22a}$ is the largest constant for which one has an inequality 
+$C\_{22a}$ is the largest constant for which one has an inequality 
 
-$L\geq C_{22a}C^{3/4}$
+$L\geq C\_{22a}C^{3/4}$
 
 
 for all knots, where $L$ is the ropelength of a knot (or link) with [crossing number](https://en.wikipedia.org/wiki/Crossing_number_(knot_theory)) $C$. The _ropelength_ $L$ is the infimum over all embeddings of the knot (or link) of the ratio of the contour length of the knot to its thickness. The _thickness_ is defined as the radius of the smallest circle that passes through any three points on the knot (where collinear points yield an infinite radius). Colloquially, the ropelength is the least amount of rope required to tie a specific knot in a rope of unit radius. See [CKS2002] for the full definition.


### PR DESCRIPTION
## Summary
The opening definition on constants/22a still had unescaped `$C_{22a}$`, so Kramdown broke the inline math the same way as in #8.

## Fix
Use `$C\_{22a}$` in the definition and the displayed inequality.


Made with [Cursor](https://cursor.com)