### PR TITLE
fix: escape inline subscripts on BHH constant page

### DIFF
--- a/constants/12a.md
+++ b/constants/12a.md
@@ -3,7 +3,7 @@
 
 ## Description of constant
 
-$C_{12} = \beta_{2}$ is the constant such that the length $L_{n}$ of the shortest tour through $n$ independent uniform random points satisfies $L_{n}/\sqrt{n}\to \beta_{2}$ almost surely.
+$C\_{12} = \beta\_{2}$ is the constant such that the length $L\_{n}$ of the shortest tour through $n$ independent uniform random points satisfies $L\_{n}/\sqrt{n}\to \beta\_{2}$ almost surely.
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
Fixes broken LaTeX rendering on `constants/12a.html` (issue #8).

## Root cause
The description line uses inline math `$C_{12}$`, `$L_{n}$`, and `$\beta_{2}$`. Kramdown treats `_` as Markdown emphasis, so multiple subscripts on one line corrupt the math before MathJax runs.

## Fix
Escape the subscript underscores (`\_`), matching #96–#107.

Fixes #8
