### PR TITLE
fix: escape inline subscripts on sphere packing constant page

### DIFF
--- a/constants/36a.md
+++ b/constants/36a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{36}=\Delta_4$ is the **(optimal) sphere packing density** in $\mathbb{R}^4$, i.e. the largest fraction of $\mathbb{R}^4$ that can be covered by congruent balls with disjoint interiors.
+$C\_{36}=\Delta\_4$ is the **(optimal) sphere packing density** in $\mathbb{R}^4$, i.e. the largest fraction of $\mathbb{R}^4$ that can be covered by congruent balls with disjoint interiors.
 <a href="#CE2003-pack-problem">[CE2003-pack-problem]</a> <a href="#CE2003-def-density">[CE2003-def-density]</a> <a href="#CE2003-greatest-density">[CE2003-greatest-density]</a>
 
 More precisely, for a packing $\mathcal{P}$ in $\mathbb{R}^4$, let $P$ denote the union of all balls in the packing, and let $B(p,R)$ denote a (Euclidean) ball of radius $R$ centered at $p$. The (upper) density of $\mathcal{P}$ is


### PR DESCRIPTION
## Summary
Fixes broken LaTeX rendering on `constants/36a.html` (issue #8).

## Root cause
The description line uses inline math `$C_{36}=\Delta_4$`. Kramdown treats `_` as Markdown emphasis, corrupting the math before MathJax runs.

## Fix
Escape the subscript underscores (`\_`), matching #96–#108.

Fixes #8
