### PR TITLE
fix: escape inline subscripts on Hadwiger constant page

### DIFF
--- a/constants/39a.md
+++ b/constants/39a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{39}=H_3$ is the **Hadwiger covering number** in dimension $3$, which can also be formulated in terms of illumination of the boundary.
+$C\_{39}=H\_3$ is the **Hadwiger covering number** in dimension $3$, which can also be formulated in terms of illumination of the boundary.
 <a href="#ABP2024-equivalence-illumination">[ABP2024-equivalence-illumination]</a>
 
 Given sets $K,L\subset \mathbb{R}^n$, let $C(K,L)$ be the minimal number of translates of $L$ needed to cover $K$.


### PR DESCRIPTION
## Summary
Fixes broken LaTeX rendering on `constants/39a.html` (issue #8).

## Root cause
The description line uses inline math `$C_{39}=H_3$`. Kramdown treats `_` as Markdown emphasis, corrupting the math before MathJax runs.

## Fix
Escape the subscript underscores (`\_`), matching #96–#110.

Fixes #8
