### PR TITLE
fix: escape inline subscripts on Steiner ratio constant page

### DIFF
--- a/constants/43a.md
+++ b/constants/43a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C_{43}$ is defined as the infimum of the ratio of the length of the Steiner Minimal Tree to the length of the Euclidean Minimum Spanning Tree over all finite sets of points $V \subseteq \mathbb{R}^2$: $C_{43} = \inf_{V}L_S(V)/L_M(V)$, where $L_S(V)$ and $L_M(V)$ denote the lengths of Steiner Minimal Tree and Minimum Spanning Tree, respectively.
+$C\_{43}$ is defined as the infimum of the ratio of the length of the Steiner Minimal Tree to the length of the Euclidean Minimum Spanning Tree over all finite sets of points $V \subseteq \mathbb{R}^2$: $C\_{43} = \inf\_{V}L\_S(V)/L\_M(V)$, where $L\_S(V)$ and $L\_M(V)$ denote the lengths of Steiner Minimal Tree and Minimum Spanning Tree, respectively.
 
 
 Consider a set $V$ of $n$ points in the Euclidean plane $\mathbb{R}^2$. A spanning tree on $V$ is a connected, acyclic graph with vertex set $V$. When the length of each edge is defined as the Euclidean distance between its endpoints, a spanning tree that minimizes the total length is called a Minimum Spanning Tree. The shortest network interconnecting all points in $V$, where the length of each edge is measured by Euclidean distance, is necessarily a tree, referred to as a Steiner Minimal Tree. A Steiner Minimal Tree may contain auxiliary vertices not in $V$. 


### PR DESCRIPTION
## Summary
Fixes broken LaTeX rendering on `constants/43a.html` (issue #8).

## Root cause
The description line packs several inline math fragments with subscripts (`$C_{43}$`, `$L_S(V)$`, etc.). Kramdown treats `_` as Markdown emphasis, so the constant definition renders as garbled HTML instead of mathematics.

## Fix
Escape the subscript underscores (`\_`), matching #96–#111.

Fixes #8
