### PR TITLE
fix: escape inline subscripts on Ihara constant page

### DIFF
--- a/constants/33a.md
+++ b/constants/33a.md
@@ -1,8 +1,8 @@
-# Ihara constant over $\mathbf{F}_2$
+# Ihara constant over $\mathbf{F}\_2$
 
 ## Description of constant
 
-$C_{33}=A(2)$ is the **Ihara constant** over $\mathbb{F}_2$.
+$C\_{33}=A(2)$ is the **Ihara constant** over $\mathbb{F}\_{2}$.
 <a href="#DM2013-def-Aq">[DM2013-def-Aq]</a>
 
 For each integer $g\ge 1$, let


### PR DESCRIPTION
## Summary
Fixes broken LaTeX rendering on `constants/33a.html` (issue #8).

## Root cause
The title and description use inline math with unescaped subscripts (`$\mathbf{F}_2$`, `$C_{33}$`, `$\mathbb{F}_2$`). Kramdown treats `_` as Markdown emphasis, corrupting the math before MathJax runs.

## Fix
Escape the subscript underscores (`\_`), matching #96–#112.

Fixes #8

## Test plan
- [ ] Verify `constants/33a.html` renders `F_2` and `C_{33}` correctly on GitHub Pages


Made with [Cursor](https://cursor.com)