### PR TITLE
fix: wrap GL_2 in math mode in 56a page title

### DIFF
--- a/constants/56a.md
+++ b/constants/56a.md
@@ -1,4 +1,4 @@
-# GL_2 Ramanujan conjecture exponent
+# $\mathrm{GL}_2$ Ramanujan conjecture exponent
 
 ## Description of constant
 We define $C\_{56} = \delta\_2$ to be the smallest real number $\delta \ge 0$ such that the following uniform bound toward the Generalized Ramanujan Conjecture holds.


### PR DESCRIPTION
## Summary
- The constant page title used bare `GL_2`; Jekyll treats `_` as emphasis outside math mode.

## Test plan
- [ ] Preview the 56a constant page and confirm the title renders as GL₂.


Made with [Cursor](https://cursor.com)