### PR TITLE
fix: restore LaTeX subscripts on Ihara constant page

### DIFF
--- a/constants/33a.md
+++ b/constants/33a.md
@@ -1,8 +1,8 @@
-# Ihara constant over $\mathbf{F}\_2$
+# Ihara constant over $\mathbf{F}_2$
 
 ## Description of constant
 
-$C\_{33}=A(2)$ is the **Ihara constant** over $\mathbb{F}\_{2}$.
+$C_{33}=A(2)$ is the **Ihara constant** over $\mathbb{F}_2$.
 <a href="#DM2013-def-Aq">[DM2013-def-Aq]</a>
 
 For each integer $g\ge 1$, let


### PR DESCRIPTION
## Summary
- Restore proper `_` subscripts inside math mode on the 33a constant page
- Reverts the regression from #113 where `\_` was used inside `$...$`, which renders literally instead of as subscripts

## Test plan
- [ ] Build the Jekyll site and confirm the page title shows F₂ correctly
- [ ] Check the opening paragraph renders $C_{33}$ and $\mathbb{F}_2$ properly


Made with [Cursor](https://cursor.com)