### PR TITLE
fix: restore LaTeX subscripts on BHH constant page

### DIFF
--- a/constants/12a.md
+++ b/constants/12a.md
@@ -3,7 +3,7 @@
 
 ## Description of constant
 
-$C\_{12} = \beta\_{2}$ is the constant such that the length $L\_{n}$ of the shortest tour through $n$ independent uniform random points satisfies $L\_{n}/\sqrt{n}\to \beta\_{2}$ almost surely.
+$C_{12} = \beta_{2}$ is the constant such that the length $L_{n}$ of the shortest tour through $n$ independent uniform random points satisfies $L_{n}/\sqrt{n}\to \beta_{2}$ almost surely.
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
- Restore normal LaTeX subscripts in the 12a constant description (`C_{12}`, `\beta_2`, `L_n`).
- Same regression as #116/#117: merged #108 escaped underscores inside `$...$` math.

## Test plan
- [ ] Open the 12a constant page and confirm subscripts render correctly in the description line.


Made with [Cursor](https://cursor.com)