### PR TITLE
fix: restore LaTeX subscripts on Hadwiger constant page

### DIFF
--- a/constants/39a.md
+++ b/constants/39a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C\_{39}=H\_3$ is the **Hadwiger covering number** in dimension $3$, which can also be formulated in terms of illumination of the boundary.
+$C_{39}=H_3$ is the **Hadwiger covering number** in dimension $3$, which can also be formulated in terms of illumination of the boundary.
 <a href="#ABP2024-equivalence-illumination">[ABP2024-equivalence-illumination]</a>
 
 Given sets $K,L\subset \mathbb{R}^n$, let $C(K,L)$ be the minimal number of translates of $L$ needed to cover $K$.


### PR DESCRIPTION
## Summary
- Restore normal LaTeX subscripts in the 39a constant description (`C_{39}`, `H_3`).
- Same regression as #116–#119: merged #111 escaped underscores inside `$...$` math.

## Test plan
- [ ] Open the 39a constant page and confirm subscripts render in the description.


Made with [Cursor](https://cursor.com)