### PR TITLE
fix: restore LaTeX subscripts on sphere packing constant page

### DIFF
--- a/constants/36a.md
+++ b/constants/36a.md
@@ -2,7 +2,7 @@
 
 ## Description of constant
 
-$C\_{36}=\Delta\_4$ is the **(optimal) sphere packing density** in $\mathbb{R}^4$, i.e. the largest fraction of $\mathbb{R}^4$ that can be covered by congruent balls with disjoint interiors.
+$C_{36}=\Delta_4$ is the **(optimal) sphere packing density** in $\mathbb{R}^4$, i.e. the largest fraction of $\mathbb{R}^4$ that can be covered by congruent balls with disjoint interiors.
 <a href="#CE2003-pack-problem">[CE2003-pack-problem]</a> <a href="#CE2003-def-density">[CE2003-def-density]</a> <a href="#CE2003-greatest-density">[CE2003-greatest-density]</a>
 
 More precisely, for a packing $\mathcal{P}$ in $\mathbb{R}^4$, let $P$ denote the union of all balls in the packing, and let $B(p,R)$ denote a (Euclidean) ball of radius $R$ centered at $p$. The (upper) density of $\mathcal{P}$ is


### PR DESCRIPTION
## Summary
- Restore normal LaTeX subscripts in the 36a constant description (`C_{36}`, `\Delta_4`).
- Same regression as #116–#121: merged #109 escaped underscores inside `$...$` math.

## Test plan
- [ ] Open the 36a constant page and confirm subscripts render in the description.


Made with [Cursor](https://cursor.com)