### PR TITLE
fix: restore LaTeX subscripts on Ramanujan exponent constant page

### DIFF
--- a/constants/56a.md
+++ b/constants/56a.md
@@ -1,7 +1,7 @@
 # GL_2 Ramanujan conjecture exponent
 
 ## Description of constant
-We define $C\_{56} = \delta\_2$ to be the smallest real number $\delta \ge 0$ such that the following uniform bound toward the Generalized Ramanujan Conjecture holds.
+We define $C_{56} = \delta_2$ to be the smallest real number $\delta \ge 0$ such that the following uniform bound toward the Generalized Ramanujan Conjecture holds.
 
 > (**Hypothesis $H_2(\delta)$, specialization of [BB2011]**) For every number field $F$, every cuspidal automorphic representation $\pi$ of $\mathrm{GL}_2(\mathbb A_F)$ with unitary central character, and every place $v$ of $F$, the local component $\pi_v$ is "$\delta$-tempered".
 


### PR DESCRIPTION
## Summary
- Restore normal LaTeX subscripts in the 56a constant description (`C_{56}`, `\delta_2`).
- Complements #115 (title math mode); merged #110 escaped underscores in the description line.

## Test plan
- [ ] Open the 56a constant page and confirm subscripts render in the description.


Made with [Cursor](https://cursor.com)