### PR TITLE
Improve C17 upper bound below 3.792

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [15a](https://teorth.github.io/optimizationproblems/constants/15a.html) | Matrix multiplication exponent | 2 | 2.371339 |
 | [15b](https://teorth.github.io/optimizationproblems/constants/15b.html) | Dual matrix multiplication exponent | >0.321334 | 1 |
 | [16](https://teorth.github.io/optimizationproblems/constants/16a.html) | Brezis–Gallouet–Wainger remainder constant on the 2D torus | $\frac{\beta + \pi}{\pi} \approx 1.82283$ | $\approx 2.15627$ |
-| [17](https://teorth.github.io/optimizationproblems/constants/17a.html) | Exponential growth constant of diagonal Ramsey numbers | $\sqrt{2} \approx 1.4142$ | 3.7992027396 |
+| [17](https://teorth.github.io/optimizationproblems/constants/17a.html) | Exponential growth constant of diagonal Ramsey numbers | $\sqrt{2} \approx 1.4142$ | 3.7919936995 |
 | [18](https://teorth.github.io/optimizationproblems/constants/18a.html) | Marton's conjecture constant (PFR) | 1 | 9 |
 | [19](https://teorth.github.io/optimizationproblems/constants/19a.html) | Berry–Esseen constant | 0.4097321837 | 0.4690 |
 | [20a](https://teorth.github.io/optimizationproblems/constants/20a.html) | Thin shell conjecture constant | 2 | $< \infty$ |

--- a/constants/17a.md
+++ b/constants/17a.md
@@ -11,6 +11,7 @@ $C\_{17}$ is the limit (if it exists) of $R(k)^{1/k}$ as $k \to \infty$, where t
 | $4$ | [ES1935] |
 | $4 - 2^{-7} = 4 - \frac{1}{128} = 3.9921875$ | [CGMS2023] | A simpler proof with $4 - 2^{-10}$ is also provided  |
 | $4 e^{-0.14/e} = 3.7992027396\dots$ | [GNNW2024] | Optimizes parameters in the [CGMS2023] approach |
+| $3.791993699438612 < 3.792$ | [Gri26] | Computer-assisted verification using Theorem 13 and Lemma 14 of [GNNW2024] |
 
 ## Known lower bounds
 
@@ -36,6 +37,10 @@ For the purposes of this page, upper (resp. lower) bounds on $C_{17}$ should be 
 - [Sah2023] Sah, A. *Diagonal Ramsey via effective quasirandomness.* Duke Math. J. 172 (2023), 545–567.
 - [CGMS2023] Campos, M.; Griffiths, S.; Morris, R.; Sahasrabudhe, J. *An exponential improvement for diagonal Ramsey.* [arXiv:2303.09521](https://arxiv.org/abs/2303.09521)
 - [GNNW2024] Gupta, P.; Ndiaye, N.; Norin, S.; Wei, L. *Optimizing the CGMS upper bound on Ramsey numbers.* [arXiv:2407.19026](https://arxiv.org/abs/2407.19026)
+- [Gri26] Max Grinsztajn.
+Code and certificate for a Ramsey upper bound below 3.792.
+GitHub repository, 2026.
+https://github.com/maaxgrin/ramsey-3792-bound
 - [BBCGHMST2024] Balister, P.; Bollobás, B.; Campos, M.; Griffiths, S.; Hurley, H.; Morris, R.; Sahasrabudhe, J.; Tiba, A. *A shorter proof of the exponential improvement for diagonal Ramsey.* [arXiv:2403.02803](https://arxiv.org/abs/2403.02803)
 - [CFS2015] Conlon, D.; Fox, J.; Sudakov, B. *Recent developments in graph Ramsey theory.* Surveys in Combinatorics 2015, London Math. Soc. Lecture Note Series 424, 49–118.
 - [GRS1990] Graham, R. L.; Rothschild, B. L.; Spencer, J. H. *Ramsey Theory.* 2nd ed., Wiley, 1990.


### PR DESCRIPTION
This PR updates the entry for C17, the exponential growth constant of diagonal Ramsey numbers, improving the recorded upper bound

```text
3.7992027396...
```

to

```text
3.791993699438612 < 3.792.
```

The proof applies Theorem 13 and Lemma 14 of Gupta--Ndiaye--Norin--Wei, *Optimizing the CGMS upper bound on Ramsey numbers* (arXiv:2407.19026), with an explicit degree-14 perturbation and a computer-assisted verification of the required inequalities.

The proof note, verifier, JSON certificate, and GitHub Actions check are available here:

https://github.com/maaxgrin/ramsey-3792-bound

Prepared with assistance from GPT-5.5 Pro.
