### PR TITLE
C_71 --- Improve lower bound for the Fourier Entropy-Influence constant to 6.521845710923046575 (n=18 certified construction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [68](https://teorth.github.io/optimizationproblems/constants/68a.html) | Korenblum's constant | 0.3554 | 0.6778994 |
 | [69](https://teorth.github.io/optimizationproblems/constants/69a.html) | Sendov radius constant | 1 | 2 |
 | [70](https://teorth.github.io/optimizationproblems/constants/70a.html) | Reverse Brunn-Minkowski constant | 1 | $<\infty$ |
-| [71](https://teorth.github.io/optimizationproblems/constants/71a.html) | Fourier Entropy-Influence constant | 6.278 | $\infty$ |
+| [71](https://teorth.github.io/optimizationproblems/constants/71a.html) | Fourier Entropy-Influence constant | 6.521845710923046575 | $\infty$ |
 | [72](https://teorth.github.io/optimizationproblems/constants/72a.html) | Polya-Vinogradov best constant (squarefree asymptotic) | 0 | $\frac{1}{4\pi}\approx 0.07958$ |
 | [73](https://teorth.github.io/optimizationproblems/constants/73a.html) | Flatness constant in dimension 3 | $2+\sqrt{2}$ | $<3.972$ |
 | [74](https://teorth.github.io/optimizationproblems/constants/74a.html) | 10-point multi-point Seshadri constant on $\mathbb{P}^2$ | $\frac{117}{370}$ | $\frac{1}{\sqrt{10}}$ |

--- a/constants/71a.md
+++ b/constants/71a.md
@@ -37,23 +37,23 @@ $$
 The conjecture is equivalent to $C_{71}<\infty$, and this remains open.
 <a href="#ODWZ2011-open-problem">[ODWZ2011-open-problem]</a>
 
-An explicit balanced, logic-monotone function on 17 variables (exact integer
+An explicit balanced, logic-monotone function on 18 variables (exact integer
 Fourier spectrum and truth table certified exactly), via the O'Donnell--Tan
 amplification rule $C \ge H/(I-1)$, gives
 
 $$
-C_{71}\ >\ 6.514326913930565372,
+C_{71}\ >\ 6.521845710923046575,
 $$
 
 and the same certificate shows the bound holds even restricted to monotone
 functions.
 
-<a href="#MI2026b">[MI2026b]</a>
+<a href="#Num2026">[Num2026]</a>
 
 Hence the best established range is
 
 $$
-6.514326913930565372\ <\ C_{71}\ \le\ \infty.
+6.521845710923046575\ <\ C_{71}\ \le\ \infty.
 $$
 
 ## Known upper bounds
@@ -71,6 +71,7 @@ $$
 | $>6.4547837$ | [[Hod2017](#Hod2017)] | Theorem 4.4 gives $C\ge \beta(1/2)>6.4547837$, even when restricted to monotone functions. <a href="#Hod2017-thm4.4">[Hod2017-thm4.4]</a> |
 | $>6.4901128435233943$ | [[MI2026](#MI2026)] | finite balanced **logic-monotone** function on 14 variables (explicit truth table), via O'Donnell–Tan amplification $C \ge H/(I-1)$; certified by exact-rational spectrum + interval arithmetic. The seed is monotone and composition preserves monotonicity, so the same bound holds even restricted to monotone functions. <a href="#MI2026-bound">[MI2026-bound]</a> |
 | $>6.514326913930565372$ | [[MI2026b](#MI2026b)] | Explicit balanced **logic-monotone** function on 17 variables via the [[OT2013](#OT2013)] amplification rule $C \ge H/(I-1)$; exact influence $261/128$; certified by exact-rational spectrum + interval arithmetic; replayable certificate, see PR. The function is monotone, so the same bound holds even restricted to monotone functions. <a href="#MI2026b-bound">[MI2026b-bound]</a> |
+| $>6.521845710923046575$ | [[Num2026](#Num2026)] | Explicit balanced **logic-monotone** function on 18 variables via the [[OT2013](#OT2013)] amplification rule $C \ge H/(I-1)$; exact influence $261/128$; obtained from the [[MI2026b](#MI2026b)] function by equalising the auxiliary-variable action (the single 4-cell auxiliary is split 2+2 with the new 18th variable), raising $H$ by exactly twice the moved spectral weight at identical influence — certified gain exactly $1/133$; exact-rational spectrum + interval arithmetic; replayable single-file certificate. The function is monotone, so the same bound holds even restricted to monotone functions. <a href="#Num2026-bound">[Num2026-bound]</a> |
 
 ## Additional comments and links
 
@@ -110,6 +111,10 @@ $$
 	  **loc:** certificate archive and this pull request
 	  **quote:** "C_71 > 6.514326913930565372 — and, by the same logic-monotone certificate, even restricted to monotone functions (full floor-truncated value 6.51432691393056537265062517595609726535914349523745739524537); certified by the replayable script below."
 
+- <a id="Num2026"></a>**[Num2026]** Numaro ([numaro.tech](https://numaro.tech)). *A certified n=18 lower bound for the Fourier Entropy-Influence constant.* [Certificate archive](https://doi.org/10.5281/zenodo.21497769), submitted to this repository (2026).
+	- <a id="Num2026-bound"></a>**[Num2026-bound]**
+	  **loc:** certificate archive, README and `check_c71_n18.py` output.
+	  **quote:** "C_71 > 6.521845710923046575 — and, by the same logic-monotone certificate, even restricted to monotone functions (full floor-truncated value 6.5218457109230465756581439729485784683666); certified by the replayable script; the strict-improvement comparison is made against the previous record's certified upper endpoint, so the gain — exactly 1/133 — is itself certified."
 ## Contribution notes
 
 Prepared with assistance from ChatGPT 5.2 Pro.


### PR DESCRIPTION
This PR improves the lower bound of constant 71a from `6.514326913930565372` ([MI2026b], PR #124) to

**C_71 > 6.521845710923046575**   (full certified floor: 6.5218457109230465756581439729485784683666...)

**Construction.** The [MI2026b] n=17 record function is a perturbed-majority-of-9 core with eight
auxiliary variables acting on the majority boundary; one auxiliary there acts on four core cells
while all others act on two — a resource-shortage artifact of n=17. We add an 18th variable and
rehost two of those four cells onto it, making the auxiliary action uniform (nine auxiliaries, two
cells each). Halving the moved coefficient magnitudes raises spectral entropy by exactly twice the
moved weight at identical total influence (I = 261/128), for a certified gain of exactly **1/133**
via the O'Donnell–Tan amplification rule C >= H/(I-1). The function is balanced and logic-monotone
(exhaustively verified), so the bound holds even restricted to monotone functions.

**Certificate (replayable in ~60 seconds).**
Archive: https://zenodo.org/records/21497769 (DOI: https://doi.org/10.5281/zenodo.21497769)

- `check_c71_n18.py` — single-file verifier (Python 3.9+, mpmath only; truth table inlined and
  SHA-256-bound). `python3 check_c71_n18.py` -> ends `ALL CERTIFIED`, exit 0. Every verdict is an
  exact rational comparison of interval endpoints; the strict-improvement comparison is made
  against the previous record's certified **upper** endpoint, so the gain is itself certified.
- `verify.py` + `fei_c71_n18_artifact.json` — independent second verifier (from-scratch numpy
  Walsh–Hadamard transform, exact-Fraction influence). `python3 verify.py fei_c71_n18_artifact.json`
  -> `RESULT: PASS`, exit 0.

**Changes in this PR.** `constants/71a.md`: description-paragraph record value, best-established
range line, one row added to the Known lower bounds table, and a [Num2026] reference entry
(mirroring the existing entry format). `README.md`: row 71 lower bound updated (note: supersedes
the pending update in PR #128).

**AI-use disclosure** (per CONTRIBUTING.md): the construction was found and certified with AI
assistance (an automated search-and-verification pipeline built on AI agents by
[Numaro](https://numaro.tech)); all results were re-run and verified by the human submitter before
this PR — both verifiers replay from the Zenodo archive alone.

Here is our report: https://numaro.tech/research/fourier-entropy-influence-2026/

— [Numaro](https://numaro.tech)
