### PR TITLE
fix: C_41b README link and inequality typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [40a](https://teorth.github.io/optimizationproblems/constants/40a.html) | Lehmer’s Mahler measure constant | 1 | 1.176280... |
 | [40b](https://teorth.github.io/optimizationproblems/constants/40b.html) | Asymptotic Dobrowolski constant for Lehmer’s problem | $9/4$ | $\infty$ |
 | [41a](https://teorth.github.io/optimizationproblems/constants/41a.html) | Moving sofa constant | 2.2195 | 2.37 (2.2195*)|
-| [41b](https://teorth.github.io/optimizationproblems/constants/41a.html) | Ambidextrous moving sofa constant | 1.64495521 | 2.2195 |
+| [41b](https://teorth.github.io/optimizationproblems/constants/41b.html) | Ambidextrous moving sofa constant | 1.64495521 | 2.2195 |
 | [42](https://teorth.github.io/optimizationproblems/constants/42a.html) | Turan's pure power sum constant | 0.5 | 0.69368 |
 | [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.8559 | 0.86602540378 |
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |

--- a/constants/41b.md
+++ b/constants/41b.md
@@ -4,7 +4,7 @@
 
 The ambidextrous moving sofa constant $C\_{41b}$ asks for the maximum area of a sofa, as defined in $C\_{41a}$ that can navigate both left and right corners inside a Z-shaped corridor of width 1, where the corners are sufficiently far apart.
 That is, the shape of the largest area (the "sofa") that can be moved from one end of the corridor to the other by a continuous rigid motion (translation and rotation).
-Trivially, $C\_{41a} \ge \_{41b}$
+Trivially, $C\_{41a} \ge C\_{41b}$
 
 ## Known upper bounds
 


### PR DESCRIPTION
## Summary
- point the C_41b table link at 41b.html (was 41a.html)
- restore missing C in C_41a ≥ C_41b

## Test plan
- [x] README link targets constants/41b.md


Made with [Cursor](https://cursor.com)