### PR TITLE
fix: C_10a best lower bound and C_1a minimum-overlap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [7b](https://teorth.github.io/optimizationproblems/constants/7b.html) | Irrationality measure of $\Gamma(1/4)$ | 2 | $10^{143}$ |
 | [8](https://teorth.github.io/optimizationproblems/constants/8a.html) | Classical zero-free region constant | 0.755106 | 4.896 |
 | [9](https://teorth.github.io/optimizationproblems/constants/9a.html) | Shannon capacity of the 7-cycle | 3.2578 | 3.3177 |
-| [10a](https://teorth.github.io/optimizationproblems/constants/10a.html) | The real Grothendieck constant | $1.67696 + 10^{-26}$ | 1.78215358819137 |
+| [10a](https://teorth.github.io/optimizationproblems/constants/10a.html) | The real Grothendieck constant | $1.67696 + 10^{-12}$ | 1.78215358819137 |
 | [10b](https://teorth.github.io/optimizationproblems/constants/10b.html) | The complex Grothendieck constant | 1.338 | 1.40491 |
 | [10c](https://teorth.github.io/optimizationproblems/constants/10c.html) | Spencer discrepancy constant (“six standard deviations suffice”) | 1.414214 | 3.674235 (3.65*) |
 | [11a](https://teorth.github.io/optimizationproblems/constants/11a.html) | $L^1$ Poincaré constant on the Hamming cube | $\sqrt{\pi/2} \approx 1.2533$ | $\pi/2 - 0.00013 \approx 1.5707$ |

--- a/constants/1a.md
+++ b/constants/1a.md
@@ -38,7 +38,7 @@ for all non-negative $f \colon \mathbb{R} \to \mathbb{R}$.
 ## Additional comments and links
 
 - [Damek Davis's meta-analysis of this problem](https://x.com/damekdavis/status/1923031798163857814).
-- [AlphaEvolve repository page for this problem](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/2.html).  This repository also contains pages for some similar autocorrelation constants, see [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/3.html), [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/4.html), and [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/6.html).  See also the [page here for the minimum overlap problem](https://teorth.github.io/optimizationproblems/constants/2.html).
+- [AlphaEvolve repository page for this problem](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/2.html).  This repository also contains pages for some similar autocorrelation constants, see [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/3.html), [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/4.html), and [here](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/6.html).  See also the [page here for the minimum overlap problem](https://teorth.github.io/optimizationproblems/constants/1b.html).
 
 ## References
 


### PR DESCRIPTION
## Summary
- README table for $C_{10a}$ listed $1.67696 + 10^{-26}$ as the best lower bound; the constant page and recent-updates note record $K_{DR} + 10^{-12}$ as best.
- On $C_{1a}$, the “minimum overlap problem” link pointed at `constants/2.html` (missing; Crouzeix is `2a`). Point it at `constants/1b.html`.

Independent of #132.

## Test plan
- [ ] Compare README $C_{10a}$ cell with `constants/10a.md` lower-bound table
- [ ] Confirm `constants/1b.html` is the Erdős minimum overlap page


Made with [Cursor](https://cursor.com)