### PR TITLE
C_38a --- Improve rigorous lower bound for square-lattice SAW connective constant to 2.6273856 (span-17 certified enumeration) [Numaro.tech]

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [35](https://teorth.github.io/optimizationproblems/constants/35a.html) | Gradient Descent Exponent | $\log_2(1+\sqrt{2}) \approx 1.271$ | 2 |
 | [36](https://teorth.github.io/optimizationproblems/constants/36a.html) | Sphere packing density in $\mathbb{R}^4$ | $\pi^2/16 \approx 0.616850$ | 0.644421 |
 | [37](https://teorth.github.io/optimizationproblems/constants/37a.html) | The degree--sensitivity exponent | $\log_{3}(6) \approx 1.63093$ | 2 |
-| [38](https://teorth.github.io/optimizationproblems/constants/38a.html) | Square-lattice self-avoiding walk connective constant | 2.625622 | 2.679193 |
+| [38](https://teorth.github.io/optimizationproblems/constants/38a.html) | Square-lattice self-avoiding walk connective constant | 2.6273856 | 2.679193 |
 | [39](https://teorth.github.io/optimizationproblems/constants/39a.html) | Hadwiger covering / illumination number in $\mathbb{R}^3$ | 8 | 14 |
 | [40a](https://teorth.github.io/optimizationproblems/constants/40a.html) | Lehmer’s Mahler measure constant | 1 | 1.176280... |
 | [40b](https://teorth.github.io/optimizationproblems/constants/40b.html) | Asymptotic Dobrowolski constant for Lehmer’s problem | $9/4$ | $\infty$ |

--- a/constants/38a.md
+++ b/constants/38a.md
@@ -39,6 +39,7 @@ $$
 | $2$ | Trivial | From the general bound $d \le \mu \le 2d-1$ with $d=2$. <a href="#SlaBounds-simple">[SlaBounds-simple]</a> |
 | $2.62002$ | <a href="#SlaBounds">[SlaBounds]</a> | Reported (Table 1) as the best rigorous lower bound for $d=2$ in this survey; the survey attributes it to <a href="#CG1993">[CG1993]</a>. <a href="#SlaBounds-table1-d2">[SlaBounds-table1-d2]</a> <a href="#SlaBounds-conway-guttmann">[SlaBounds-conway-guttmann]</a> |
 | $2.625622$ | <a href="#FV2017">[FV2017]</a> | Reported as a rigorous lower bound in <a href="#FV2017">[FV2017]</a> (attributed there to <a href="#Jen2004-lb">[Jen2004-lb]</a>). <a href="#FV2017-bounds-square">[FV2017-bounds-square]</a> <a href="#FV2017-ref-182">[FV2017-ref-182]</a> |
+| $2.6273856$ | [Num2026] | Kesten irreducible-bridge renewal exactly as in [Jen2004-lb], extended two span levels past the 2004 computation (span $L=17$, series length $N=260$) by an exact cell-by-cell finite-lattice transfer matrix (CRT big-integer arithmetic); the certificate is a single exact big-integer inequality (self-contained checker included), and secondary certificates at Jensen's own span ($L=15$, $N=260$ gives $2.6256270$) and at $L=16$ ($2.6265705$) independently also exceed $2.625622$. <a href="#Num2026-bound">[Num2026-bound]</a> |
 
 ## Additional comments and links
 
@@ -56,6 +57,11 @@ $$
 - Surveys/background: <a href="#FV2017">[FV2017]</a>, <a href="#SSSY2014">[SSSY2014]</a>.
 
 ## References
+- <a id="Num2026"></a>**[Num2026]** Numaro ([numaro.tech](https://numaro.tech)). *An improved rigorous lower bound for the square-lattice SAW connective constant.* [Certificate archive](https://doi.org/10.5281/zenodo.21546041), submitted to this repository (2026).
+	- <a id="Num2026-bound"></a>**[Num2026-bound]**
+	  **loc:** certificate archive, `check_saw38a_L17.py` output and README.
+	  **quote:** "certified: mu(Z^2) >= R = 2.627385640... (exact dyadic 340282366920938463463374607431768211456/129513673858566230428673965530967449326); ALL CERTIFIED."
+
 
 - <a id="FV2017"></a>**[FV2017]** Friedli, Roland; Velenik, Yvan. *Statistical Mechanics of Lattice Systems: a Concrete Mathematical Introduction.* Cambridge University Press (2017). DOI: [10.1017/9781316882603](https://doi.org/10.1017/9781316882603). [Google Scholar](https://scholar.google.com/scholar?q=Statistical+Mechanics+of+Lattice+Systems+a+Concrete+Mathematical+Introduction+Friedli+Velenik). [Author PDF](https://unige.ch/math/folks/velenik/smbook/Statistical_Mechanics_of_Lattice_Systems.pdf)
 	- <a id="FV2017-bounds-square"></a>**[FV2017-bounds-square]**  


### PR DESCRIPTION
This PR improves the rigorous lower bound of constant 38a from `2.625622` (Iwan Jensen 2004, as
reported in [FV2017] and [SlaBounds]) — unimproved for 22 years — to

**mu(Z^2) >= 2.6273856**   (exact dyadic rational 2^128 / 129513673858566230428673965530967449326)

**Method.** Jensen's own method, two compute levels deeper: exact enumeration of span-bounded
bridges by a cell-by-cell finite-lattice transfer matrix (span L=17, series length N=260;
≈5.6×10^8 states, ≈8.7×10^8 transitions, CRT big-integer arithmetic), then Kesten's irreducible-
bridge renewal converts the counts into the certified inequality  sum a_n R^{-n} >= 1  =>
mu >= R — one exact big-integer comparison. The 2004 record was computed at span L=15, N=250 on
a 1 GHz Alpha with 2.5 GB RAM; this run used 192 cores and hundreds of GB. As independent
confirmation, the same table restricted to lower spans already certifies 2.6265705 (L=16) and
2.6256270 (L=15, N=260, Jensen's own span) — three nested certificates clear the record. Sanity:
all three bounds sit safely below the non-rigorous estimate 2.63815853 [JSG2016].

**Calibration.** The enumerator reproduces OEIS A001411 exactly; the bridge series b_0..b_21
agrees with three independent enumerator implementations; and the pipeline reproduces Jensen's
published intermediate bounds digit-for-digit (2.583704 / 2.601224) before exceeding his frontier.

**Certificate (replayable, ~minutes).**
Archive: https://zenodo.org/records/21546041 (DOI: https://doi.org/21546041)
- `check_saw38a_L17.py` + `bridge_table_record_L17.json` (SHA-256-bound) — self-contained stdlib
  checker: re-enumerates all bridges of length <=13 by brute force, checks structural invariants
  and the published series prefix, re-derives irreducible counts via the span renewal, and verifies
  the Kesten inequality and the strict improvement as pure big-integer comparisons. Ends
  `ALL CERTIFIED`, exit 0.
- `verify.py` — an independent second implementation, `VERIFY: PASS *** RECORD BEATEN ***`, exit 0.

**Changes in this PR.** `constants/38a.md`: one row added to the Known lower bounds table + a
[Num2026] reference entry. `README.md`: row 38 lower bound updated.

**AI-use disclosure** (per CONTRIBUTING.md): the enumeration engine and certificate were built and
run with AI assistance (an automated search-and-verification pipeline built on Claude/GPT/Gemini agents by
[Numaro](https://numaro.tech)); all results were re-run and verified by the human submitter before
this PR — both checkers replay from the archive alone.

— [Numaro](https://numaro.tech)
