### PR TITLE
fix: correct cross-links on C_1b and C_13a pages

### DIFF
--- a/constants/13a.md
+++ b/constants/13a.md
@@ -36,7 +36,7 @@ $C_{13a}$ is the infimal area of a **convex** domain $\Omega$ that can contain a
   However, the constant is still positive in this case [Mar1979], [FO2018].
 - It is not sufficient to test covering of polygonal paths [PWW2007].
 - [Wikipedia page for this problem](https://en.wikipedia.org/wiki/Moser%27s_worm_problem)
-- See also: [Lebesgue’s universal covering problem](https://teorth.github.io/optimizationproblems/constants/22b.html).
+- See also: [Lebesgue’s universal covering problem](https://teorth.github.io/optimizationproblems/constants/13b.html).
 
 ## References
 

--- a/constants/1b.md
+++ b/constants/1b.md
@@ -42,7 +42,7 @@ for all non-negative $f,g: [-1,1] \to [0,1]$ with $f+g=1$ on $[-1,1]$ and $\int_
 - [AlphaEvolve repository page for this problem](https://google-deepmind.github.io/alphaevolve_repository_of_problems/problems/5.html)
 - The [Wikipedia page for this problem](https://en.wikipedia.org/wiki/Minimum_overlap_problem)
 - [Haugland's page for this problem](https://www.neutreeko.net/mop/index.htm).
-- See also the page [here](https://teorth.github.io/optimizationproblems/constants/1.html) for the autocorrelation constant related to Sidon sets.
+- See also the page [here](https://teorth.github.io/optimizationproblems/constants/1a.html) for the autocorrelation constant related to Sidon sets.
 
 ## References
 


### PR DESCRIPTION
## Summary
- On $C_{1b}$, the “see also” link for the Sidon autocorrelation constant pointed at `constants/1.html`, which does not exist. Point it at `constants/1a.html`.
- On $C_{13a}$ (Moser’s worm), the “see also” link labeled Lebesgue’s universal covering problem pointed at `constants/22b.html` (tight alternating knot). Point it at `constants/13b.html`.

## Test plan
- [ ] Confirm `constants/1a.md` / `1a.html` is the Sidon autocorrelation page
- [ ] Confirm `constants/13b.md` / `13b.html` is Lebesgue’s convex universal cover page
- [ ] Confirm GitHub Pages build succeeds

Made with [Cursor](https://cursor.com)