### PR TITLE
Update Constant 86a

### DIFF
--- a/constants/86a.md
+++ b/constants/86a.md
@@ -66,8 +66,6 @@ $$
 
 - **Caution on the literature.** A paper titled "A generalization of the Schur–Siegel–Smyth trace problem" (K. Pratt, G. Shakan, A. Zaharescu, *J. Math. Anal. Appl.* **436** (2016), 489–500, [arXiv:1511.08837](https://arxiv.org/abs/1511.08837)) was retracted in 2023 (*J. Math. Anal. Appl.* **518** (2023), 126784, DOI: [10.1016/j.jmaa.2022.126784](https://doi.org/10.1016/j.jmaa.2022.126784)). It still appears prominently in searches on this topic.
 
-- [Wikipedia page on the Schur–Siegel–Smyth trace problem](https://en.wikipedia.org/wiki/Schur%E2%80%93Siegel%E2%80%93Smyth_trace_problem)
-
 ## References
 
 - [Sch18] Schur, I. *Über die Verteilung der Wurzeln bei gewissen algebraischen Gleichungen mit ganzzahligen Koeffizienten.* Mathematische Zeitschrift **1** (1918), 377–402. DOI: [10.1007/BF01465096](https://doi.org/10.1007/BF01465096).


### PR DESCRIPTION
Remove a link to a seemingly-nonexistent Wikipedia page.