### PR TITLE
Fix five citation keys in 15a.md that do not match the page's reference list

### DIFF
--- a/constants/15a.md
+++ b/constants/15a.md
@@ -21,14 +21,14 @@ We define $C\_{15a}$ to be the matrix multiplication exponent $\omega$, the smal
 | $2.4785$ | [S1987] | Introduces laser method. |
 | $2.375477$ | [CW1990] | Introduces Coppersmith-Winograd tensors. |
 | $2.41$ | [CKSU2005] | Uses an alternative group-theoretic method. |
-| $2.373689703$ | [S2010, DS2013] | This and subsequent improvements up to [L2014] modify and optimize the framework of Coppersmith-Winograd to analyze higher powers of the tensor. |
+| $2.373689703$ | [S2010, DS2013] | This and subsequent improvements up to [LG2014] modify and optimize the framework of Coppersmith-Winograd to analyze higher powers of the tensor. |
 | $2.372873$ | [V2012, V2014] |  |
 | $2.373$ | [Z2012] |  |
-| $2.3728639$ | [L2014] |  |
+| $2.3728639$ | [LG2014] |  |
 | $2.3728596$ | [AV2020] | Improved analysis of the laser method. |
-| $2.371866$ | [DWZ23] | This and subsequent improvements introduce and optimize an asymmetric modification of the laser method. |
-| $2.371552$ | [WXXZ24] |  |
-| $2.371339$ | [ADWXXZ25] |  |
+| $2.371866$ | [DWZ2022] | This and subsequent improvements introduce and optimize an asymmetric modification of the laser method. |
+| $2.371552$ | [VXXZ2023] |  |
+| $2.371339$ | [ADVXXZ2024] |  |
 
 ## Known lower bounds
 
@@ -50,7 +50,7 @@ We define $C\_{15a}$ to be the matrix multiplication exponent $\omega$, the smal
 - [S1969] Strassen, V. *Gaussian elimination is not optimal.* Numerische Mathematik **13** (1969), 354–356.
 - [P1978] Pan, V. Ya. *Strassen's algorithm is not optimal: Trilinear technique of aggregating, uniting and canceling for constructing fast algorithms for matrix operations.* In FOCS 1978, 166–176.
 - [P1979] Pan, V. Ya. *Field extension and trilinear aggregating, uniting and canceling for the acceleration of matrix multiplication.* In FOCS 1979, 28–38.
-- [BCRL79] Bini, D.; Capovani, M.; Romani, F.; Lotti, G. $O(n^{2.7799})$ complexity for $n \times n$ approximate matrix multiplication. Information Processing Lett. **8** (1979), 234–235.
+- [BCRL1979] Bini, D.; Capovani, M.; Romani, F.; Lotti, G. $O(n^{2.7799})$ complexity for $n \times n$ approximate matrix multiplication. Information Processing Lett. **8** (1979), 234–235.
 - [B1980] Bini, D. *Relations between exact and approximate bilinear algorithms. Applications.* Calcolo **17** (1980), 87–97.
 - [P1980] Pan, V. Ya. *New fast algorithms for matrix operations.* SIAM J. Computing **9** (1980), 321–342.
 - [S1981] Schönhage, A. *Partial and total matrix multiplication.* SIAM J. Computing **10** (1981), 434–455.


### PR DESCRIPTION
The bounds table and comments on the matrix multiplication exponent page cite five keys that the page's own `## References` section does not define. Each has a near-identical entry under a different key, so no reference is missing. The table and the reference list just spell five of them differently, and a reader following a citation does not find it.

| Line | Currently | Changed to |
|---|---|---|
| 53 (reference) | `[BCRL79]` | `[BCRL1979]` |
| 24 (comment) | `[L2014]` | `[LG2014]` |
| 27 (table) | `[L2014]` | `[LG2014]` |
| 29 (table) | `[DWZ23]` | `[DWZ2022]` |
| 30 (table) | `[WXXZ24]` | `[VXXZ2023]` |
| 31 (table) | `[ADWXXZ25]` | `[ADVXXZ2024]` |

I have changed the table in four cases and the reference in one, following the convention in the page's own reference list: of its thirty definitions, all use four-digit years except `BCRL79`; Le Gall is `LG` (`LG2014`, `LG2017`); and Vassilevska Williams is `V` (`V2012`, `V2012a`, `V2014`). `L2014` also collides with `L2017`, which is Landsberg. If you would rather keep the table spellings and change the five reference keys instead, I am happy to redo it that way.

No bound, value, attribution, or reference target is changed, and no README cell is affected (none of these keys appears in README.md).

*AI disclosure: an AI assistant was used to find these mismatches and prepare this patch. The references and proposed keys have been reviewed and verified by me.*
