### PR TITLE
Sync 3b lower bound in README with constant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [1b](https://teorth.github.io/optimizationproblems/constants/1b.html) | Erdős minimum overlap constant | 0.379005 | 0.380868 |
 | [2](https://teorth.github.io/optimizationproblems/constants/2a.html) | Crouzeix constant | 2 | $1+\sqrt{2} \approx 2.4142$ |
 | [3a](https://teorth.github.io/optimizationproblems/constants/3a.html) | Gyarmati-Hennecart-Ruzsa sum-difference constant | 1.1835129324 (1.19102809*) | 1.33333 |
-| [3b](https://teorth.github.io/optimizationproblems/constants/3b.html) | Kakeya sums-differences constant | >1.77898 | 1.83333 |
+| [3b](https://teorth.github.io/optimizationproblems/constants/3b.html) | Kakeya sums-differences constant | 1.77898884 | 1.83333 |
 | [3c](https://teorth.github.io/optimizationproblems/constants/3c.html) | 4-slope Kakeya-type sum-difference constant | 1.67473389 | 1.75 |
 | [3d](https://teorth.github.io/optimizationproblems/constants/3d.html) | Single-set sum-difference exponent | 2 | 2 |
 | [4a](https://teorth.github.io/optimizationproblems/constants/4a.html) | Cap set constant | 2.2203 | 2.756 |
@@ -147,6 +147,7 @@ Bounds for which the level of available verification is currently at minimal lev
 - [3a](https://teorth.github.io/optimizationproblems/constants/3a.html) **improved lower bound (limit value):** $C_{3a} \geq 1.187326127925948*$ by [Numaro](https://numaro.tech), 23 Jul 2026.
 - [3a](https://teorth.github.io/optimizationproblems/constants/3a.html) **improved lower bound (limit value):** $C_{3a} \geq 1.19102809*$ by [L. Kleinwaks](https://github.com/kleinwaks/masked-digit-sum-difference-bound), 24 Jul 2026.
 - [3d](https://teorth.github.io/optimizationproblems/constants/3d.html) **solved:** $C_{3d} = 2$ by [H. Lin and S. Li](https://arxiv.org/abs/2607.27199), 29 Jul 2026.
+- [3b](https://teorth.github.io/optimizationproblems/constants/3b.html) **improved lower bound:** $C_{3b} \geq 1.77898884$ by Mosaic Intelligence, [entropy certificate](https://doi.org/10.5281/zenodo.20794135) on a 13-point support.
 
 ## Maintainers
 


### PR DESCRIPTION
constants/3b.md's Known lower bounds table has, as its most recent row, a bound of 1.77898884 attributed to [MI2026] (an entropy construction on a 13-point support), which supersedes the prior >1.77898 row from [GGSWT2025]. The README.md master table (row for 3b) still showed the older >1.77898 value in the "Best lower bound" column, and there was no corresponding entry in the "Recent progress" changelog.

This is the "most common defect" flagged in CONTRIBUTING.md: a bound improved on a constant's page but not reflected in the README table.

Change: update the 3b row in the README table to 1.77898884, and add a Recent progress line for it, consistent with how other bound updates are recorded elsewhere in the same file.

Verified by reading constants/3b.md's lower-bound table directly (1.77898884 > 1.77898, and lower bounds improve upward) and cross-checking README.md's existing row for 3b, which had not been updated.