### PR TITLE
Sync C_47 lower bound in README with the constant page

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in degree-$d$ Boolean functions | 1.5 | 4.394 |
 | [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490180063290061 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |
-| [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{11+\sqrt{61}}{12}\approx 1.5675208$ | 4 |
+| [47](https://teorth.github.io/optimizationproblems/constants/47a.html) | Centered Hardy-Littlewood maximal constant in dimension $2$ | $\frac{3}{4}-\frac{\sqrt{2}}{4}+\frac{\sqrt{6}}{2}\approx 1.6211915$ | 4 |
 | [48](https://teorth.github.io/optimizationproblems/constants/48a.html) | One-dimensional convex sub-Gaussian comparison constant | $\approx 5.33386$ | $\approx 5.33386$ |
 | [49](https://teorth.github.io/optimizationproblems/constants/49a.html) | Erdős–Szemerédi $3$-sunflower-free capacity | >1.551 ($\geq 1.554*$) | $\frac{3}{2^{2/3}} \approx 1.88988$ |
 | [50](https://teorth.github.io/optimizationproblems/constants/50a.html) | Approximation ratio for quantum Max Cut | 0.614 | $<1$ (0.5 for product states) |


### PR DESCRIPTION
The README row for $C_{47}$ (centered Hardy–Littlewood maximal constant in dimension 2) lists

$$\frac{11+\sqrt{61}}{12}\approx 1.5675208$$

as the best known lower bound. The [47a page](constants/47a.md) records that value as the weaker of its two lower bounds — it is Melas' exact $c_1$ carried up to $c_2$ by the monotonicity $c_{d+1}\ge c_d$. The other row on the same page, Aldaz 2000 Proposition 1.4 specialized to $n=2$, gives

$$\frac{3}{4}-\frac{\sqrt{2}}{4}+\frac{\sqrt{6}}{2}\approx 1.6211915$$

which is strictly larger, so it is the better lower bound. This syncs the README to it; the page itself already has both rows and needs no change. The upper bound column (4) already matches the page's best.

Numerically: $3/4-\sqrt2/4+\sqrt6/2 = 1.6211914807\ldots$ against $(11+\sqrt{61})/12 = 1.5675208063\ldots$

How I found it: the bound tables are chronological and the template notes they "can include bounds that are inferior to the previous bounds", so the last row is not always the best. I scripted a comparison of every README row against the min (upper) and max (lower) over its page's tables. That flagged three candidates; the other two were false positives I am leaving alone — $C_{52}$'s 4.453 is conditional on an extra hypothesis, and $C_{81}$'s 2.175398 is Klyve's RH-conditional bound, so in both cases the README's weaker unconditional value is the right one to show.

One concern only; no other rows touched.