### PR TITLE
Fix three citation keys that do not resolve

### DIFF
--- a/constants/22b.md
+++ b/constants/22b.md
@@ -14,7 +14,7 @@ Upper bounds are typically found by constructing alternating torus knots or link
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 |$2\pi+2\approx 8.28$ | Trivial | Hopf chain link of stadium curves
-| 8.50| [O2013] | Double helix |
+| 8.50| [Olsen2013] | Double helix |
 | 7.63| [Huh2018] | Four-strand superhelix |
 | $1+\pi\sqrt{4+\frac{1}{\pi^2}}\approx 7.36$| [Klotz2021] | Wrapped circle |
 | 7.31|  [Kim2024] | Asymmetric double helix |

--- a/constants/46a.md
+++ b/constants/46a.md
@@ -36,9 +36,9 @@ $$
 
 - Many papers work with the paraboloid model surface (or a bounded subset thereof); by localization and rescaling, the best-known exponents for compact strictly convex surfaces (including $S^2$) track the paraboloid results up to standard $\varepsilon$-losses that can often be removed by "epsilon removal lemmas".
 
-- For most of the results in the literature, the $L^\infty(S^2)$ norm on the right-hand side can be replaced with $L^q(S^2)$ for various $q$; for instance, in the Tomas-Stein theorem one can take $q=2$.  There are also bilinear and multilinear variants of the conjecture.  See for instance [Ta2004] for more discussion.
+- For most of the results in the literature, the $L^\infty(S^2)$ norm on the right-hand side can be replaced with $L^q(S^2)$ for various $q$; for instance, in the Tomas-Stein theorem one can take $q=2$.  There are also bilinear and multilinear variants of the conjecture.  See for instance [Tao2004] for more discussion.
 
-- Stein's restriction conjecture $C_{46}=3$ implies the Kakeya conjecture in ${\mathbb R}^3$ (see, e.g., [Ta2004]), which was recently proven in [WZ2025].
+- Stein's restriction conjecture $C_{46}=3$ implies the Kakeya conjecture in ${\mathbb R}^3$ (see, e.g., [Tao2004]), which was recently proven in [WZ2025].
 
 ## References
 

--- a/constants/52a.md
+++ b/constants/52a.md
@@ -100,7 +100,7 @@ satisfiability threshold conjecture,  *Random Structures & Algorithms* 7(1), 59-
 
 - [A2000] D. Achlioptas, Setting 2 variables at a time yields a new lower bound for random 3-SAT. *Proceedings of the thirty-second annual ACM symposium on Theory of computing*, 28-37,  2000.
 
-- [AC2000] D. Achioptas, and G.B. Sorkin, Optimal myopic algorithms for random 3-SAT, *Proceedings 41st Annual Symposium on Foundations of Computer Science*, IEEE Computer Society, 590-600, 2000.
+- [AS2000] D. Achlioptas, and G.B. Sorkin, Optimal myopic algorithms for random 3-SAT, *Proceedings 41st Annual Symposium on Foundations of Computer Science*, IEEE Computer Society, 590-600, 2000.
 
 - [KKL2002] A.C. Kaporis, L.M. Kirousis, and E.G. Lalas, The probabilistic analysis of a greedy satisfiability algorithm, *Algorithms - ESA*, 574-586, 2002.
 


### PR DESCRIPTION
Same class of issue as #141. Each of these keys appears in a page's bound tables or comments but matches no entry in that page's own reference list, so the citation dead-ends for a reader.

| page | cited | defined | resolution |
| --- | --- | --- | --- |
| 22b | `[O2013]` (8.50 upper bound) | `[Olsen2013]` | Olsen & Bohr, *A principle for ideal torus knots* — the double-helix construction the row's comment names |
| 46a | `[Ta2004]` (×2, in comments) | `[Tao2004]` | Tao, *Some recent progress on the restriction conjecture* — the survey both sentences point at. `[Tao2003]`, the bilinear estimate paper, is a separate entry already cited correctly elsewhere |
| 52a | `[AS2000]` (3.26 lower bound) | `[AC2000]` | same Achlioptas–Sorkin paper |

For 52a I changed the **reference entry** rather than the citation: `[AC2000]` is cited nowhere on the page, and the authors are Achlioptas and Sorkin, so `AS` is the key that matches the page's own convention (compare `[KKSVZ2007]` for Kaporis–Kirousis–Stamatiou–Vamvakari–Zito). The entry also spelled the first author "Achioptas"; that is corrected in the same line.

How I found it: scripted every page's cited keys against the keys its `## References` section defines, over all 111 constant pages. After this change exactly one page still reports:

- **56a** uses eight keys (`[BB2011]`, `[JS1981]`, `[KiSh2002]`, `[KS2003]`, `[Li2006]`, `[LRS1999]`, `[MS2004]`, `[Sar2005]`) and has **no `## References` section at all**. I have deliberately not touched that one — supplying those eight entries means identifying the papers, and guessing at citations in a reference database seemed worse than leaving it visible. Happy to open it as an issue, or to add them if someone can confirm the intended sources.

One concern only; no bound values changed.