### PR TITLE
C_81: mark Klyve's upper bound as conditional on GRH

### DIFF
--- a/constants/81a.md
+++ b/constants/81a.md
@@ -17,9 +17,9 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 | Bound                  | Reference      | Comments                                      |
 | ---------------------- | -------------- | --------------------------------------------- |
-| 1.8267324395006        | [N1995]        | Led to the discovery of the Pentium FDIV bug. |
-| 1.83180806343237901198 | [N2010]        |                                               |
-| 1.840503               | [PT2018]       |                                               |
+| 1.8267324395006        | [N1995]        | A lower bound is just a partial sum, since $B$ is a sum of positive terms; this one comes from the enumeration to $10^{14}$ of that reference.  The much-quoted $B \approx 1.902$ from the same computations is an extrapolation, not a bound.  This enumeration led to the discovery of the Pentium FDIV bug. |
+| 1.83180806343237901198 | [N2010]        | Continues the same enumeration through the twin-prime pairs from $10^{16}$ to $2\cdot 10^{16}$. |
+| 1.840503               | [PT2018]       | Unconditional, and the value carried in the README table. |
 
 
 ## Additional comments and links
@@ -36,7 +36,7 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 - [CP2005] Crandall, Richard and Pomerance, Carl. *Prime Numbers: A Computational Perspective*, second edition, Springer, New York, 2005.
 - [K2007] Klyve, Dominic. [Explicit Bounds on Twin Primes and Brun’s Constant](https://doi.org/10.1349/ddlp.153).  PhD thesis, Dartmouth College.
-- [N1995] Nicely, Thomas. [Enumeration to 1e14 of the twin primes and Brun's constant](https://faculty.lynchburg.edu/~nicely/twins/twins.html).
-- [N2010] Nicely, Thomas. [Enumeration of the twin-prime pairs from 1e16 to 2e16](https://faculty.lynchburg.edu/~nicely/twins/t2_0001.html).
+- [N1995] Nicely, Thomas. [Enumeration to 1e14 of the twin primes and Brun's constant](https://faculty.lynchburg.edu/~nicely/twins/twins.html).  (The Lynchburg pages return 404 as of 17 August 2026; the author died in 2019 and the trnicely.net domain has since been taken over by an unrelated site, so it is not a substitute.)
+- [N2010] Nicely, Thomas. [Enumeration of the twin-prime pairs from 1e16 to 2e16](https://faculty.lynchburg.edu/~nicely/twins/t2_0001.html).  (Also 404 as of 17 August 2026.)
 - [PT2018] Platt, Dave and Trudgian, Tim. [Improved bounds on Brun's constant](https://doi.org/10.48550/arXiv.1803.01925).
 

--- a/constants/81a.md
+++ b/constants/81a.md
@@ -8,8 +8,8 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 | Bound                  | Reference      | Comments                                      |
 | ---------------------- | -------------- | --------------------------------------------- |
-| 2.175398               | [K2007]        |                                               |
-| 2.288513               | [PT2018]       |                                               |
+| 2.175398               | [K2007]        | **Conditional on the Generalised Riemann Hypothesis.**  [PT2018, §1] records this as "under the assumption of the Generalised Riemann Hypothesis we have $B < 2.1754$", so it is not comparable with the unconditional rows. |
+| 2.288513               | [PT2018]       | Unconditional, and the value carried in the README table.  Sharpens the Crandall--Pomerance bound by about 13%. |
 
 
 ## Known lower bounds
@@ -23,6 +23,11 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 ## Additional comments and links
 
+- The upper bounds here are of two kinds.  An unconditional bound follows from a
+  Crandall--Pomerance style estimate; a smaller bound is available under the
+  Generalised Riemann Hypothesis.  The README table records the best
+  *unconditional* bound, which is why it reads $2.288513$ rather than the
+  smaller conditional $2.175398$ in the table above.
 - Similar constants exist for other prime families, e.g., cousin primes.
 - [Wikipedia page on Brun's theorem](https://en.wikipedia.org/wiki/Brun%27s_theorem)
 

--- a/constants/81a.md
+++ b/constants/81a.md
@@ -8,6 +8,7 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 | Bound                  | Reference      | Comments                                      |
 | ---------------------- | -------------- | --------------------------------------------- |
+| 2.347                  | [CP2005]       | The first rigorous upper bound, from the Crandall--Pomerance argument; attributed as such in [PT2018, §1]. |
 | 2.175398               | [K2007]        | **Conditional on the Generalised Riemann Hypothesis.**  [PT2018, §1] records this as "under the assumption of the Generalised Riemann Hypothesis we have $B < 2.1754$", so it is not comparable with the unconditional rows. |
 | 2.288513               | [PT2018]       | Unconditional, and the value carried in the README table.  Sharpens the Crandall--Pomerance bound by about 13%. |
 
@@ -33,7 +34,8 @@ $C\_{81a}$, Brun's Constant, is the sum of the reciprocals of the twin primes.
 
 ## References
 
-- [K2007] Klyve, Dominic. [Explicit Bounds on Twin Primes and Brun’s Constant](https://doi.org/10.1349/ddlp.153).
+- [CP2005] Crandall, Richard and Pomerance, Carl. *Prime Numbers: A Computational Perspective*, second edition, Springer, New York, 2005.
+- [K2007] Klyve, Dominic. [Explicit Bounds on Twin Primes and Brun’s Constant](https://doi.org/10.1349/ddlp.153).  PhD thesis, Dartmouth College.
 - [N1995] Nicely, Thomas. [Enumeration to 1e14 of the twin primes and Brun's constant](https://faculty.lynchburg.edu/~nicely/twins/twins.html).
 - [N2010] Nicely, Thomas. [Enumeration of the twin-prime pairs from 1e16 to 2e16](https://faculty.lynchburg.edu/~nicely/twins/t2_0001.html).
 - [PT2018] Platt, Dave and Trudgian, Tim. [Improved bounds on Brun's constant](https://doi.org/10.48550/arXiv.1803.01925).


### PR DESCRIPTION
## What the page says today

The upper-bound table for $C_{81}$ lists

| Bound | Reference | Comments |
| ----- | --------- | -------- |
| 2.175398 | [K2007] | |
| 2.288513 | [PT2018] | |

with both comment cells empty, while the README carries $2.288513$. A reader
comparing the two concludes the README is stale by one row.

It is not. The two bounds are not comparable: [PT2018, §1] states

> An excellent exposition of their proof is given in a thesis by Klyve [8] who
> also shows that under the assumption of the Generalised Riemann Hypothesis we
> have $B < 2.1754$.

and the same paper's abstract gives its own $1.840503 < B < 2.288513$ as
*unconditional*. So the README is right and the page was missing the one fact
that makes it right.

## Changes

Three commits, all on `constants/81a.md`; no bound values are changed and the
README needs no edit.

1. Mark the [K2007] row as conditional on GRH and the [PT2018] row as
   unconditional, and explain in "Additional comments" why the README shows the
   larger number.
2. Add the first upper bound, $B < 2.347$ (Crandall–Pomerance), which the table
   was missing — [PT2018, §1]: "The first upper bound appears to be given by
   Crandall and Pomerance [5], who showed that $B < 2.347$". The 13% improvement
   claimed in that paper's abstract is measured against it. Rows stay in
   chronological order, per CONTRIBUTING.
3. Say what the lower-bound rows are: partial sums, which is what makes them
   bounds at all, and which distinguishes them from the extrapolated
   $B \approx 1.902$ that is far more widely quoted and is *not* a bound.

## One thing I could not fix

Both Nicely references 404:

```
https://faculty.lynchburg.edu/~nicely/twins/twins.html    -> 404
https://faculty.lynchburg.edu/~nicely/twins/t2_0001.html  -> 404
```

He died in 2019 and the Lynchburg pages are gone. `trnicely.net` still resolves
but is now an unrelated commercial site, so it is not a substitute — I checked
before proposing it. archive.org was returning 502/503 while I was working, so I
did not want to paste a snapshot URL I had not actually opened. The dead state is
noted inline instead, so the next reader does not repeat the search; happy to
swap in a Wayback link if you would rather have one.
