### PR TITLE
Attach the right witness to the 857.567 record in 87a

### DIFF
--- a/constants/87a.md
+++ b/constants/87a.md
@@ -16,8 +16,8 @@ Upper bounds on $C_{87}$ come from explicit constructions of infinite tamely ram
 | ----- | --------- | -------- |
 | $1058.565$ | [Mar1978] | Martinet's original construction of infinite $2$-class field towers of totally real number fields. |
 | $954.293$ | [HM2002] | Hajir–Maire, refined Golod–Shafarevich with tame ramification. |
-| $913.493$ | [Mar2006] | Martin, further refinement of the [HM2002] construction. |
-| $857.567$ | [HMR2019] | Hajir–Maire–Ramakrishna, "cutting towers" via the refined Golod–Shafarevich criterion; explicit example is an $8$-th root class-field tower over the totally real field of [HM2002] with $2$-class group of rank $8$, yielding $\mathrm{rd} \le 3^4\cdot 5^4\cdot 7^4\cdot 13^2\cdot 29^4\cdot 53^2\cdot 109^2 \le 857.5662\dots$  Current record. |
+| $913.493$ | [Mar2006] | Martin, further refinement of the [HM2002] construction; the degree-$8$ field of [HMR2019, §3.3.1] has discriminant $3^4\cdot 5^4\cdot 7^4\cdot 13^2\cdot 29^4\cdot 53^2\cdot 109^2$ and root discriminant $< 913.4927$. |
+| $857.567$ | [HMR2019] | Hajir–Maire–Ramakrishna, "cutting towers" via the refined Golod–Shafarevich criterion.  The totally real example [HMR2019, §3.3.3] is a *degree-$12$* field $\mathrm{K}$ with $\mathrm{rd}_{\mathrm{K}} < 770.6432$, cut at a single prime above $13$ of norm $13$, giving $\mathrm{rd}_{\mathrm{K}_S^{[1]}} = \mathrm{rd}_{\mathrm{K}}\cdot 13^{\frac{1}{12}(1-\frac{1}{2})} < 857.5662\dots$ — a saving of a factor $13^{1/24}$.  Current record. |
 
 ## Known lower bounds
 


### PR DESCRIPTION
Closes #150 (reported by @u00dxk2, who did the diagnosis).

The `[HMR2019]` row of `constants/87a.md` quoted

> $\mathrm{rd} \le 3^4\cdot 5^4\cdot 7^4\cdot 13^2\cdot 29^4\cdot 53^2\cdot 109^2 \le 857.5662\dots$

That product is `484887097019201067725625`, a 24-digit integer, so it cannot be a root discriminant. It is also not the witness behind this record.

I checked both halves against the paper itself ([ar5iv 1901.04354](https://ar5iv.labs.arxiv.org/html/1901.04354)) rather than taking the issue's word for it:

- **§3.3.1, "An example of J. Martin"** — a degree-8 field whose *discriminant* is exactly that factorization, "and the root discriminant is less than 913.4927". `484887097019201067725625^(1/8) = 913.492694…`, which is the `913.493` on the `[Mar2006]` row directly above. So the factorization belongs one row up.
- **§3.3.3, "The totally real case"** — a *different, degree-12* field with `rd_K < 770.6432`, cut at a single prime above 13 of norm 13, giving `rd_{K_S^[1]} = rd_K · 13^(1/12·(1−1/2)) < 857.5662`, which the paper calls "a new record with savings by a factor of 13^{1/24}". `770.6432 · 13^(1/24) = 857.566203…`.

So the record value `857.567` is right, but the explicit witness beside it — the factorization and the "8-th root … rank 8" description — came from §3.3.1. §3.3.3's field has `d_2 G = 9`, not rank 8.

The row now carries the degree-12 construction that actually produces the bound, and the factorization moves up to the `[Mar2006]` row where its 8th root is the quoted value. **No bound changes.**

Note @u00dxk2 offered to open this themselves and asked which wording you'd prefer — happy for this to be closed in favour of theirs if you'd rather, or reworded here.

This was AI-assisted; the two arithmetic checks and both quotations were verified against the arXiv full text.