### PR TITLE
add return to main page footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,5 +22,9 @@
   <body>
     <article class="markdown-body">
     {{ content }}
+    {% if page.path contains "constants/" %}
+    <p class="home-link"><a href="../">&larr; Back to the table of constants</a></p>
+    {% endif %}
+    </article>
   </body>
 </html>


### PR DESCRIPTION
Currently, it seems there is no way to navigate to the main page from any of the pages on individual constants. This PR adds to the constant pages a small footer with a link back to the main table. Hopefully this would make the site easier to navigate.

I used a coding agent to make these changes and tested them locally.