### PR TITLE
Fix citation keys Olsen2013 and Tao2004

### DIFF
--- a/constants/22b.md
+++ b/constants/22b.md
@@ -14,7 +14,7 @@ Upper bounds are typically found by constructing alternating torus knots or link
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 |$2\pi+2\approx 8.28$ | Trivial | Hopf chain link of stadium curves
-| 8.50| [O2013] | Double helix |
+| 8.50| [Olsen2013] | Double helix |
 | 7.63| [Huh2018] | Four-strand superhelix |
 | $1+\pi\sqrt{4+\frac{1}{\pi^2}}\approx 7.36$| [Klotz2021] | Wrapped circle |
 | 7.31|  [Kim2024] | Asymmetric double helix |

--- a/constants/46a.md
+++ b/constants/46a.md
@@ -36,9 +36,9 @@ $$
 
 - Many papers work with the paraboloid model surface (or a bounded subset thereof); by localization and rescaling, the best-known exponents for compact strictly convex surfaces (including $S^2$) track the paraboloid results up to standard $\varepsilon$-losses that can often be removed by "epsilon removal lemmas".
 
-- For most of the results in the literature, the $L^\infty(S^2)$ norm on the right-hand side can be replaced with $L^q(S^2)$ for various $q$; for instance, in the Tomas-Stein theorem one can take $q=2$.  There are also bilinear and multilinear variants of the conjecture.  See for instance [Ta2004] for more discussion.
+- For most of the results in the literature, the $L^\infty(S^2)$ norm on the right-hand side can be replaced with $L^q(S^2)$ for various $q$; for instance, in the Tomas-Stein theorem one can take $q=2$.  There are also bilinear and multilinear variants of the conjecture.  See for instance [Tao2004] for more discussion.
 
-- Stein's restriction conjecture $C_{46}=3$ implies the Kakeya conjecture in ${\mathbb R}^3$ (see, e.g., [Ta2004]), which was recently proven in [WZ2025].
+- Stein's restriction conjecture $C_{46}=3$ implies the Kakeya conjecture in ${\mathbb R}^3$ (see, e.g., [Tao2004]), which was recently proven in [WZ2025].
 
 ## References
 


### PR DESCRIPTION
## Summary
- Replace `[O2013]` with `[Olsen2013]` and `[Ta2004]` with `[Tao2004]` so citations resolve.

## Test plan
- [ ] Build / check that those keys resolve in the bibliography