### PR TITLE
fix: correct Achlioptas spelling in the AC2000 reference

### DIFF
--- a/constants/52a.md
+++ b/constants/52a.md
@@ -100,7 +100,7 @@ satisfiability threshold conjecture,  *Random Structures & Algorithms* 7(1), 59-
 
 - [A2000] D. Achlioptas, Setting 2 variables at a time yields a new lower bound for random 3-SAT. *Proceedings of the thirty-second annual ACM symposium on Theory of computing*, 28-37,  2000.
 
-- [AC2000] D. Achioptas, and G.B. Sorkin, Optimal myopic algorithms for random 3-SAT, *Proceedings 41st Annual Symposium on Foundations of Computer Science*, IEEE Computer Society, 590-600, 2000.
+- [AC2000] D. Achlioptas, and G.B. Sorkin, Optimal myopic algorithms for random 3-SAT, *Proceedings 41st Annual Symposium on Foundations of Computer Science*, IEEE Computer Society, 590-600, 2000.
 
 - [KKL2002] A.C. Kaporis, L.M. Kirousis, and E.G. Lalas, The probabilistic analysis of a greedy satisfiability algorithm, *Algorithms - ESA*, 574-586, 2002.
 


### PR DESCRIPTION
The A2000 entry already spelled Achlioptas correctly; the AC2000 bibliography line had dropped the l.