### PR TITLE
Correct three bound-table values, and drop an impossible upper bound on C_8

### DIFF
--- a/constants/1a.md
+++ b/constants/1a.md
@@ -12,7 +12,7 @@ for all non-negative $f \colon \mathbb{R} \to \mathbb{R}$.
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $\pi/2 = 1.57059$ | [SS2002] | |
+| $\pi/2 = 1.5707963\dots$ | [SS2002] | |
 | $1.50992$ | [MV2009] | |
 | $1.5053$ | [GGSWT2025] | May 2025 announcement, AlphaEvolve
 | $1.503164$ | [GGSWT2025] | Dec 2025 preprint release, AlphaEvolve

--- a/constants/1b.md
+++ b/constants/1b.md
@@ -19,7 +19,7 @@ for all non-negative $f,g: [-1,1] \to [0,1]$ with $f+g=1$ on $[-1,1]$ and $\int_
 | $0.4$ | [MRS1956]| |
 | $0.385694$ | Haugland (unpublished, 1993) | |
 | $0.382002$ | [H1996] | |
-| $0.380927$ | [H2016] | |
+| $0.380926$ | [H2016] | |
 | $0.380924$ | [GGSWT2025] | AlphaEvolve |
 | $0.380876$ | [YKLBMWKCZGS2026] | TTT-Discover |
 | $0.380871$ | [T2026] | TogetherAI |
@@ -31,7 +31,7 @@ for all non-negative $f,g: [-1,1] \to [0,1]$ with $f+g=1$ on $[-1,1]$ and $\int_
 | ----- | --------- | -------- |
 | $1/4=0.25$ | [E1955] |  |
 | $1-1/\sqrt{2} \approx 0.292893$ | Scherk (unpublished, 1955) | |
-| $(4-\sqrt{6})/5 \approx 0.310679$ | [S1958] |  |
+| $(4-\sqrt{6})/5 \approx 0.310102$ | [S1958] |  |
 | $\sqrt{4-\sqrt{15}} \approx 0.356393$ | [M1959] |  |
 | $0.379005$ | [W2022] |
 

--- a/constants/8a.md
+++ b/constants/8a.md
@@ -8,7 +8,6 @@ $C\_{8} = R$ is the least constant such that there are no zeroes $\sigma+it$ of 
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $0$ | Trivial | |
 | $34.82$ | [dlVP1899] | Implies the prime number theorem|
 | $19$ | [RS1962] | |
 | $9.64591$ | [S1970] | |
@@ -23,7 +22,7 @@ $C\_{8} = R$ is the least constant such that there are no zeroes $\sigma+it$ of 
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $2/\log \gamma_{1} \approx 0.755106$ | - | Optimal assuming RH |
+| $2/\log \gamma\_{1} \approx 0.755106$ | - | Unconditional: $\gamma\_{1} = 14.1347\dots$ is the ordinate of the lowest zero of $\zeta$, and that zero has $\sigma = 1/2$, so any admissible $R$ must satisfy $1/2 \leq 1 - 1/(R\log\gamma\_{1})$. Optimal assuming RH. |
 
 ## Additional comments and links
 


### PR DESCRIPTION
I recomputed every "closed form = decimal" and "closed form ≈ decimal" pair recorded in `constants/` and `README.md`, and checked the results against the source each row cites. Four rows came out wrong; everything else agrees to the precision printed.

**`constants/1a.md`, first upper-bound row.** It reads $\pi/2 = 1.57059$. But $\pi/2 = 1.5707963\dots$, so the printed value is low by about $2\times10^{-4}$ and is not an expansion of the closed form it is attached to. Changed to $\pi/2 = 1.5707963\dots$.

**`constants/1b.md`, Swierczkowski row.** It reads $(4-\sqrt{6})/5 \approx 0.310679$, but $(4-\sqrt{6})/5 = 0.3101020514\dots$. The closed form is the one to keep, not the decimal: the Wikipedia article on the minimum overlap problem records Swierczkowski's 1958 result as $M(n) > (4-\sqrt{6})n/5$, "approximately $0.310n$". Changed the decimal to $0.310102$.

**`constants/1b.md`, Haugland 2016 row.** It reads $0.380927$. The abstract of [arXiv:1609.08000](https://arxiv.org/abs/1609.08000) says "A step function that improves the upper bound from 0.382002... to 0.380926... is given", and the row directly above already carries Haugland's earlier $0.382002$ with the source's own digits. Changed to $0.380926$. Rounding the last place up would still be a valid upper bound, but it disagrees with the source and with every neighbouring row's convention.

**`constants/8a.md`, upper-bound table.** The first row records $0$ as an upper bound on $C_8$. That asserts $C_8 \leq 0$, which contradicts the lower bound $2/\log\gamma_1 \approx 0.755106$ recorded a few lines below it on the same page. It is not a misordered chronological entry either: every later row in that table (34.82, 19, 9.64591, …) is larger, so as written the table is a descending history that begins below its own endpoint. Removed the row.

I did not move it into the lower-bound table, where $0$ appears on 20a, 45a, 61a and about twenty other pages. $C_8$ is the least $R$ such that there is no zero $\sigma+it$ with $\lvert t\rvert \geq 2$ and $\sigma > 1 - 1/(R\log\lvert t\rvert)$; for $R < 0$ that threshold lies above $1$, where $\zeta$ has no zeros at all, so a negative $R$ satisfies the condition vacuously and the definition is only meaningful under an implicit $R > 0$. The genuine trivial constraint is the one already in the table, so I put the reason on that row instead: $\gamma_1 = 14.1347\dots$ is the ordinate of the lowest zero of $\zeta$, that zero has $\sigma = 1/2$, and any admissible $R$ must therefore satisfy $1/2 \leq 1 - 1/(R\log\gamma_1)$. This is unconditional; RH is needed only for the matching upper bound, which is what the existing "Optimal assuming RH" note was recording.

While editing that row I escaped its subscripts as `\_{1}`, following the rendering section of CONTRIBUTING — the added comment puts three inline `_` on one line, which kramdown would otherwise pair into an `<em>` span.

None of these four rows is a best-known bound, so no cell in `README.md` changes and the file is untouched.

What I ran: the recomputation above in Python (`math`, no CAS), against every math span in the repository, not only the ones I changed; a table-arity check over the three edited files (three columns, four pipes per row); and `curl … | grep '<em>'` against the live 1a, 1b and 8a pages, which confirms none of them currently has math eaten by kramdown, so the escaping edit is the only rendering-relevant change here. I did not attempt to verify the underlying theorems, only the arithmetic and the transcription from the cited sources.

AI disclosure, per the policy in CONTRIBUTING: I used Claude Opus 5 to run the sweep across the repository and to draft this description. Each of the four disagreements was rechecked by hand, and the Haugland and Swierczkowski figures were checked against the arXiv abstract and the Wikipedia article respectively rather than from the model's own recollection.
