### PR TITLE
Problem 43 (Steiner ratio): certificate-layer lower bound 0.860

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Bounds for which the level of available verification is currently at minimal lev
 - [2](https://teorth.github.io/optimizationproblems/constants/2a.html) **solved:** $C_2 = 2$ — Crouzeix's conjecture, by [S. Jin](https://www.preprints.org/manuscript/202607.1919), 27 Jul 2026; an independent proof by a different route followed in [E. Lorist and F. L. Schwenninger](https://arxiv.org/abs/2608.03841), 4 Aug 2026.
 - [3a](https://teorth.github.io/optimizationproblems/constants/3a.html) **improved lower bound (limit value):** $C_{3a} \geq 1.19519192*$ by [L. Kleinwaks](https://github.com/kleinwaks/masked-digit-sum-difference-bound), 14 Aug 2026.
 - [15a](https://teorth.github.io/optimizationproblems/constants/15a.html) **improved upper bound:** $C_{15a} \leq 2.371177$ by [E. Dupont, M. Eisenberger, B. Kozlovskii, A. Mehrabian, F. J. R. Ruiz, A. See, R. Zhou, J. Alman, V. Vassilevska Williams, M. Balog](https://arxiv.org/abs/2608.16884), 17 Aug 2026.
+- [43](https://teorth.github.io/optimizationproblems/constants/43a.html) **improved lower bound:** $C_{43} \geq 0.860$ (exact $43/50$; certificate-layer result on the lemma set of [KHSHGW2026](https://arxiv.org/abs/2601.22365)) by [J. Savva](https://doi.org/10.5281/zenodo.22223485), 1 Sep 2026.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [41a](https://teorth.github.io/optimizationproblems/constants/41a.html) | Moving sofa constant | 2.2195 | 2.37 (2.2195*)|
 | [41b](https://teorth.github.io/optimizationproblems/constants/41b.html) | Ambidextrous moving sofa constant | 1.64495521 | 2.2195 |
 | [42](https://teorth.github.io/optimizationproblems/constants/42a.html) | Turan's pure power sum constant | >0.5 | 0.69368 (0.6906538*) |
-| [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.8559 | 0.86602540378 |
+| [43](https://teorth.github.io/optimizationproblems/constants/43a.html) | Gilbert-Pollak conjecture (Steiner ratio) | 0.860 | 0.86602540378 |
 | [44](https://teorth.github.io/optimizationproblems/constants/44a.html) | Maximal number of relevant variables in Boolean functions of degree $d$ | 1.5 | 4.394 |
 | [45](https://teorth.github.io/optimizationproblems/constants/45a.html) | Density of odd integers that are the sum of a prime and a power of two | 0.107648 | 0.490180063290061 |
 | [46](https://teorth.github.io/optimizationproblems/constants/46a.html) | Fourier restriction constant for the 2-sphere | 3 |  $\frac{22}{7}\approx 3.142857$  |

--- a/constants/43a.md
+++ b/constants/43a.md
@@ -25,11 +25,13 @@ Consider a set $V$ of $n$ points in the Euclidean plane $\mathbb{R}^2$. A spanni
 | $0.8$ | [DH1983] |  |
 | $0.824$ | [CG1985] |  |
 | $0.8559$ | [KHSHGW2026] | New improvement, preprint |
+| $0.860$ | [S2026] | Certificate layer, independently verified; same lemma set as [KHSHGW2026] |
 
 
 ## Additional comments
 
 * In 1968, Gilbert and Pollak conjectured that Steiner ratio is $\sqrt{3}/2 \approx 0.866$, but this remains unproven. More information can be found at [Wikipedia page on the Gilbert-Pollak conjecture](https://en.wikipedia.org/wiki/Gilbert%E2%80%93Pollak_conjecture).
+* The $0.8559$ and $0.860$ bounds are computer-assisted results of the same kind: a finite set of per-region inequality certificates resting on a layer of human-proved geometric lemmas. [S2026] independently re-verified the [KHSHGW2026] certificate layer (330,193,755 records, zero failures) with clean-room software, then regenerated the partitions at the higher target using the same lemma set and verified all 1,104,177,103 resulting regions. Both bounds are conditional on the [KHSHGW2026] lemma layer.
 
 ## References
 
@@ -39,3 +41,4 @@ Consider a set $V$ of $n$ points in the Euclidean plane $\mathbb{R}^2$. A spanni
 - **[DH1983]** Du, D.-Z. and Hwang, F. K. *A new bound for the steiner ratio.* Transactions of the American Mathematical Society, 278(1):137–148, 1983.
 - **[CG1985]** Chung, F. R. and Graham, R. L. *A new bound for euclidean steiner minimal trees.* Annals of the New York Academy of Sciences, 440(1):328–346, 1985.
 - **[KHSHGW2026]** Ke, Y., Huang, T., Shu, Y., He, D., Gai, J., and Wang, L. *Towards Solving the Gilbert-Pollak Conjecture via Large Language Models.* [arXiv:2601.22365](https://arxiv.org/abs/2601.22365). Preprint (2026).
+- **[S2026]** Claude Fable 5 (Anthropic) and Savva, J. *An Independent Verification of the Gilbert-Pollak Certificate Layer and a Certificate-Layer Bound of $0.860$ for the Steiner Ratio.* [doi:10.5281/zenodo.22223485](https://doi.org/10.5281/zenodo.22223485). Preprint (2026). Code and data: [github.com/aimathpapers/Steiner_Ratio](https://github.com/aimathpapers/Steiner_Ratio).


### PR DESCRIPTION
This updates the Gilbert-Pollak lower bound from 0.8559 to **0.860** (exact rational 43/50), a certificate-layer result built directly on the machinery of the current record holder, [KHSHGW2026] (arXiv:2601.22365).

**What was done.** Their lemma set and case decomposition are used unchanged. Their published partition generator was re-run with only its target-rho constant modified (a one-line diff against the pinned upstream commit `709673a8`), and every one of the **1,104,177,103** regenerated regions was verified non-positive at the exact rational 43/50 by an independently implemented verifier — Arb ball arithmetic with outward rounding, exact-rational rho, all-2^n-vertices semantics; 244,138,895 regions were additionally certified over their entire box. Zero failures, zero invalid records, zero inconclusive enclosures.

The same verifier first independently re-verified the published 0.8559 certificate layer in full (330,193,755 records, zero failures) — to my knowledge its first independent replication. That audit also established, by an exact per-record critical-rho computation, that the published partition's supremal certifiable bound is 0.8559000606: the generator subdivides only until each certificate clears zero by 1e-6, so the partition was pinned to its target rather than to the mathematics. That is what makes the higher target reachable by regeneration alone.

**Claim scope, stated plainly.** Like the incumbent entry, this is a computer-assisted certificate result resting on the lemma layer of [KHSHGW2026] (trapped-point bounds, case-decomposition topology, monotonicity/unimodality claims). Those claims concern geometry and never rho, so they transfer from 0.8559 to 0.860 unchanged; the 244.1M regions closed over their whole box do not need the unimodality claim at all. Partition coverage is the generator's construction, exactly as in the published work. The comment column and the constants page are worded accordingly rather than presenting this as an unconditional theorem.

**Reproduce it.** https://github.com/aimathpapers/Steiner_Ratio (MIT), archived at https://doi.org/10.5281/zenodo.22223485. Four commands: fetch the pinned upstream sources (hash-verified — nothing unlicensed is redistributed), regenerate a partition at 0.860, verify it at exact 43/50, run the margin analysis. Certificate SHA-256 hashes and per-run records are in the bundle; the full paper is in `paper/`.

**Disclosure.** The verification software, the analysis and the paper were produced by an AI system (Claude Fable 5, Anthropic) working under my direction; every mathematical claim rests on certified interval arithmetic and is reproducible from the archived artifact. The authors of [KHSHGW2026] were notified before this PR was opened. All credit for the underlying method is theirs; this contribution is the independent verification stack, the exact-rational analysis that identified the subdivision tolerance as the binding constraint, and the computation.
