### PR TITLE
fix(C50): GP19's 1/2 is product-state only, not a general upper bound

### DIFF
--- a/constants/50a.md
+++ b/constants/50a.md
@@ -19,7 +19,6 @@ $$C_{50} = \sup_f \min_G
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
 | $< 1$ | [PG25] | There exists $\alpha<1$, such that it is NP-hard to compute a value approximating QMC to within approximation ratio $\alpha$. |
-| 0.5   | [GP19]    | best possible product state approximation
 
 
 ## Known lower bounds
@@ -39,6 +38,8 @@ $$C_{50} = \sup_f \min_G
 
 
 ## Additional comments
+The $1/2$ figure from [GP19] is the optimal *product-state* approximation ratio (cf. the $0.498$ product-state lower bound in the table above), not a general upper bound on the entangled constant $C_{50}$.
+
 Improved ratios can be obtained on triangle-free and bipartite graphs [K22].
 
 Related questions are:


### PR DESCRIPTION
## Summary
- Remove `0.5 | [GP19]` from the general upper-bounds table in `constants/50a.md`.
- Keep `<1 | [PG25]|...`.
- Note under Additional comments that GP19's 1/2 is the optimal *product-state* approximation ratio (cf. the 0.498 product-state lower bound), not an upper bound on the entangled constant.

Known lower bounds already list `0.614 | [BBKL26]`, so listing 0.5 as a general upper bound on `C_50` is inconsistent.

Does not touch citation-key edits in open #156.