### PR TITLE
fix(C56): add missing JS1981 and BB2011 bibliography entries

### DIFF
--- a/constants/56a.md
+++ b/constants/56a.md
@@ -70,6 +70,10 @@ Conjecturally (and implied by the Langlands functoriality conjectures), one has 
 
 - See also: the [Wikipedia page on the Ramanujan–Petersson conjecture](https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Petersson_conjecture) (for a quick orientation) and Sarnak's survey [Sar2005] (for a detailed representation-theoretic overview).
 
+- [BB2011] Blomer, Valentin; Brumley, Farrell. *On the Ramanujan conjecture over number fields.* Annals of Math. **174** (2011), 581–605. [arXiv:1003.0559](https://arxiv.org/abs/1003.0559).
+
+- [JS1981] Jacquet, Hervé; Shalika, Joseph A. *On Euler products and the classification of automorphic representations I.* Amer. J. Math. **103** (1981), 499–558. Rankin–Selberg / unitarity trivial bound $\delta\le 1/2$.
+
 - [KiSh2002] Kim, Henry H.; Shahidi, Freydoon. *Cuspidality of symmetric powers with applications.* Duke Math. J. **112** (2002), 177–197. DOI: 10.1215/S0012-9074-02-11215-0.
 
 - [KS2003] Kim, Henry H.; Sarnak, Peter. *Refined estimates towards the Ramanujan and Selberg conjectures.* Appendix 2 in: H. H. Kim, *Functoriality for the exterior square of $\mathrm{GL}_4$ and the symmetric fourth of $\mathrm{GL}_2$.* J. Amer. Math. Soc. **16** (2003), no. 1, 139–183. DOI: 10.1090/S0894-0347-02-00410-1.


### PR DESCRIPTION
## Summary
- Add bibliography entries for `[JS1981]` and `[BB2011]` on `constants/56a.md`.
- Keys match the bound table exactly; style matches the existing `- [KEY] ...` list on that page.

Deferred from the citation-audit discussion on closed #145 (56a cited both keys without defining them).