### PR TITLE
Order C53 upper-bound table chronologically

### DIFF
--- a/constants/53a.md
+++ b/constants/53a.md
@@ -86,8 +86,8 @@ Published work before the 2019 preprint includes Gao (2000) on rank-$3$ groups a
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $4$ | <a href="#Grinsztajn2026">[Grinsztajn2026]</a> | From the pointwise estimate $D(C_n^3)\le 4n-P(n)-2$, where $P(n)=\max_{p^a\parallel n}p^a$. Since $P(n)\ge2$, this gives $C_{53}\le4$. |
 | $20369$ | <a href="#Zak2019">[Zak2019]</a> | From Corollary 3.11: $D(C_n^3)\le 20369(n-1)+1$ for all $n\ge 2$, hence $C_{53}\le 20369$. <a href="#Zak2019-cor3.11">[Zak2019-cor3.11]</a> |
+| $4$ | <a href="#Grinsztajn2026">[Grinsztajn2026]</a> | From the pointwise estimate $D(C_n^3)\le 4n-P(n)-2$, where $P(n)=\max_{p^a\parallel n}p^a$. Since $P(n)\ge2$, this gives $C_{53}\le4$. |
 
 ## Known lower bounds
 


### PR DESCRIPTION
## Summary
- CONTRIBUTING treats bound tables as chronological histories.
- C53 listed Grinsztajn2026 ($4$) before Zak2019 ($20369$).
- Swap so the older bound comes first (README best-bound unchanged).

## Test plan
- [x] Table order is now Zak2019 then Grinsztajn2026