### PR TITLE
Order C47 upper-bound table chronologically

### DIFF
--- a/constants/47a.md
+++ b/constants/47a.md
@@ -32,8 +32,8 @@ the optimal weak-type $(1,1)$ constant of the centered Hardy–Littlewood maxima
 
 | Bound | Reference | Comments |
 | ----- | --------- | -------- |
-| $4$ | [Tao2010] | The Vitali-covering proof can be sharpened from $3^d$ to $2^d$ by covering centers with $(2+\varepsilon)$-dilates of a disjoint subcollection and letting $\varepsilon\downarrow 0$. The same argument applies to $\ell_\infty$ balls, i.e. axis-parallel cubes; hence $c_2\le 2^2=4$. [Tao2010-ex42] |
 | $9$ | [Tao2006] | The standard covering-lemma proof gives an explicit constant $3^d$ in the weak-type $(1,1)$ inequality, and the same argument applies to cubes; hence $c_2\le 3^2=9$. [Tao2006-weak-3d] [Tao2006-cubes] |
+| $4$ | [Tao2010] | The Vitali-covering proof can be sharpened from $3^d$ to $2^d$ by covering centers with $(2+\varepsilon)$-dilates of a disjoint subcollection and letting $\varepsilon\downarrow 0$. The same argument applies to $\ell_\infty$ balls, i.e. axis-parallel cubes; hence $c_2\le 2^2=4$. [Tao2010-ex42] |
 
 ## Known lower bounds
 


### PR DESCRIPTION
## Summary
- C47 listed Tao2010 ($4$) before Tao2006 ($9$).
- Order Tao2006 then Tao2010 to match chronological table convention.

## Test plan
- [x] Table order is now Tao2006 then Tao2010