### PR TITLE
Mark Baek2024 sofa upper bound as unverified

### DIFF
--- a/constants/41a.md
+++ b/constants/41a.md
@@ -12,7 +12,7 @@ The problem asks for the shape of the largest area (the "sofa") that can be move
 | ----- | --------- | -------- |
 | $2 \sqrt{2}$ | [Hammersley1968] | |
 | 2.37 | [KR2018] | Best published bound, using a computer-assisted proof scheme |
-| 2.2195 | [Baek2024] | Announced bound, matching the Gerver construction |
+| 2.2195* | [Baek2024] | Announced (unverified) bound, matching the Gerver construction |
 
 ## Known lower bounds
 


### PR DESCRIPTION
## Summary
- README already shows C41a upper as `2.37 (2.2195*)`.
- The constant page listed Baek's 2.2195 without `*`, looking certified.
- Mark `2.2195*` and note announced/unverified.

## Test plan
- [x] Table bound now `2.2195*`