### PR TITLE
Constant 88a - replace Wikipedia link

### DIFF
--- a/constants/88a.md
+++ b/constants/88a.md
@@ -36,7 +36,7 @@ More generally one writes $H\_m := \liminf\_{n\to\infty}(p\_{n+m} - p\_n)$ for $
 
 - **Relation to [$C\_{66}$](https://teorth.github.io/optimizationproblems/constants/66a.html).** The level of distribution of the primes is what drives all of these bounds, and $C\_{66} = 1$ (Elliott–Halberstam) would give $H\_1 \le 12$. Note however that the equidistribution estimates actually used here — Zhang's, Polymath's $\tfrac12+\tfrac7{300}$, and Stadlmann's $\tfrac12+\tfrac1{40}$ — are for **smooth (friable) moduli** with well-factorable weights, and so do **not** lower-bound $C\_{66}$, which is defined over all moduli $q \le Q$. See the caution on the [$C\_{88b}$](https://teorth.github.io/optimizationproblems/constants/88b.html) page.
 
-- [Wikipedia page on bounded gaps between primes](https://en.wikipedia.org/wiki/Bounded_gaps_between_primes)
+- [Wikipedia page on Polignac's conjecture](https://en.wikipedia.org/wiki/Polignac's_conjecture)
 
 ## References
 


### PR DESCRIPTION
Replaces a dead Wikipedia link with the link for the page on [Polignac's conjecture](https://en.wikipedia.org/wiki/Polignac's_conjecture).