### PR TITLE
Constant 88a - update upper bound to 186 (GPT 6 Astra)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Bounds for which the level of available verification is currently at minimal lev
 | [85](https://teorth.github.io/optimizationproblems/constants/85a.html) | Exponent for commutators close to the identity | 1 | 4 |
 | [86](https://teorth.github.io/optimizationproblems/constants/86a.html) | Schur–Siegel–Smyth trace constant | 1.80203 | 1.8216 |
 | [87](https://teorth.github.io/optimizationproblems/constants/87a.html) | Martinet's constant for totally real number fields | 60.8395 | 857.567 |
-| [88a](https://teorth.github.io/optimizationproblems/constants/88a.html) | Bounded prime gap constant | 2 | 240 |
+| [88a](https://teorth.github.io/optimizationproblems/constants/88a.html) | Bounded prime gap constant | 2 | 186 |
 | [88b](https://teorth.github.io/optimizationproblems/constants/88b.html) | Exponent for bounded gaps between many primes | 0 | 3.8075 |
 
 

--- a/constants/88a.md
+++ b/constants/88a.md
@@ -21,6 +21,7 @@ More generally one writes $H\_m := \liminf\_{n\to\infty}(p\_{n+m} - p\_n)$ for $
 | $600$ | [May15] | Maynard, via a multidimensional generalization of the Selberg sieve, using only Bombieri–Vinogradov. Obtained independently by Tao. |
 | $246$ | [Pol14b] | Polymath8b, generalizing the Maynard sieve further together with extensive numerical work. Stood as the record for twelve years. |
 | $240$ | [Sta26] | Stadlmann: "the Bombieri–Vinogradov theorem can be combined with newer equidistribution estimates for smooth moduli", the latter being the exponent of distribution $\tfrac12 + \tfrac1{40}$ of [Sta25]. Preprint of 31 August 2026. |
+| $186$ | [O26] | |
 
 ## Known lower bounds
 
@@ -47,6 +48,7 @@ More generally one writes $H\_m := \liminf\_{n\to\infty}(p\_{n+m} - p\_n)$ for $
 - [May15] Maynard, James. *Small gaps between primes.* Annals of Mathematics **181** (2015), no. 1, 383–413. DOI: [10.4007/annals.2015.181.1.7](https://doi.org/10.4007/annals.2015.181.1.7).
 - [Sta25] Stadlmann, Julia. *On primes in arithmetic progressions and bounded gaps between many primes.* Advances in Mathematics **468** (2025), Paper No. 110190. DOI: [10.1016/j.aim.2025.110190](https://doi.org/10.1016/j.aim.2025.110190). [arXiv:2309.00425](https://arxiv.org/abs/2309.00425).
 - [Sta26] Stadlmann, Julia. *Bounded gaps between primes.* Preprint, 31 August 2026. [arXiv:2608.31126](https://arxiv.org/abs/2608.31126).
+- [O26] OpenAI. *Prime Gaps at Most 186.* https://cdn.openai.com/pdf/51126fac-1b68-4128-9666-c908bcc16033/short_gaps.pdf.
 
 ## Contribution notes
 


### PR DESCRIPTION
Updates the upper bound on bounded prime gaps to 186.